### PR TITLE
add feature: groupAllFieldsUntilNextGroupAttribute and closedByDefault

### DIFF
--- a/Editor/Playa/RendererGroup/DOTweenPlayGroup.cs
+++ b/Editor/Playa/RendererGroup/DOTweenPlayGroup.cs
@@ -75,7 +75,12 @@ namespace SaintsField.Editor.Playa.RendererGroup
         {
             MethodRenderer methodRenderer = renderer as MethodRenderer;
             Debug.Assert(methodRenderer != null, $"You can NOT nest {renderer} in {this}");
-            _doTweenMethods.Add((methodRenderer.FieldWithInfo.MethodInfo, methodRenderer.FieldWithInfo.MethodInfo.GetCustomAttribute<DOTweenPlayAttribute>()));
+
+            var doTweenPlayAttribute = methodRenderer.FieldWithInfo.Groups.OfType<DOTweenPlayAttribute>().FirstOrDefault();
+            if (doTweenPlayAttribute != null)
+            {
+                _doTweenMethods.Add((methodRenderer.FieldWithInfo.MethodInfo, doTweenPlayAttribute));
+            }
         }
 
         public void Render()

--- a/Editor/Playa/RendererGroup/SaintsRendererGroup.cs
+++ b/Editor/Playa/RendererGroup/SaintsRendererGroup.cs
@@ -30,12 +30,13 @@ namespace SaintsField.Editor.Playa.RendererGroup
         private GUIStyle _foldoutSmallStyle;
         private GUIStyle _titleLabelStyle;
 
-        private bool _foldout = true;
+        private bool _foldout;
 
-        public SaintsRendererGroup(string groupPath, ELayout eLayout)
+        public SaintsRendererGroup(string groupPath, ELayout eLayout, bool closedByDefault)
         {
             _groupPath = groupPath;
             _eLayout = eLayout;
+            _foldout = !closedByDefault;
         }
 
         public void Add(string groupPath, ISaintsRenderer renderer)
@@ -608,7 +609,7 @@ namespace SaintsField.Editor.Playa.RendererGroup
                         borderTopRightRadius = radius,
                     },
                 };
-                if(_eLayout.HasFlag(ELayout.TitleOut))
+                if (_eLayout.HasFlag(ELayout.TitleOut))
                 {
                     if(_eLayout.HasFlag(ELayout.Background))
                     {
@@ -638,10 +639,11 @@ namespace SaintsField.Editor.Playa.RendererGroup
                 Foldout foldout = new Foldout
                 {
                     text = _groupPath.Split('/').Last(),
+                    value = _foldout,
                 };
-                if(_eLayout.HasFlag(ELayout.TitleOut))
+                if (_eLayout.HasFlag(ELayout.TitleOut))
                 {
-                    if(_eLayout.HasFlag(ELayout.Background))
+                    if (_eLayout.HasFlag(ELayout.Background))
                     {
                         foldout.style.backgroundColor = new Color(53f / 255, 53f / 255, 53f / 255, 1f);
                     }

--- a/Editor/Playa/RendererGroup/SaintsRendererGroup.cs
+++ b/Editor/Playa/RendererGroup/SaintsRendererGroup.cs
@@ -487,6 +487,7 @@ namespace SaintsField.Editor.Playa.RendererGroup
             string curTab = null;
             
             VisualElement root = null;
+            ToolbarToggle foldoutToggle = null;
             
             VisualElement titleRow = new VisualElement
             {
@@ -519,12 +520,6 @@ namespace SaintsField.Editor.Playa.RendererGroup
                     },
                 })
                 .ToArray();
-
-            // ReSharper disable once ConvertToLocalFunction
-            Action<(ToolbarToggle toggle, bool value)> setTabToggle = tabToggle =>
-            {
-                tabToggle.toggle.value = tabToggle.value;
-            };
 
             // ReSharper disable once ConvertToLocalFunction
             Action<string> switchTab = tab =>
@@ -576,7 +571,7 @@ namespace SaintsField.Editor.Playa.RendererGroup
             {
                 if (show)
                 {
-                    if(hasTitle)
+                    if (hasTitle)
                     {
                         toolbar.style.display = DisplayStyle.Flex;
                     }
@@ -584,7 +579,7 @@ namespace SaintsField.Editor.Playa.RendererGroup
                 }
                 else
                 {
-                    if(hasTitle)
+                    if (hasTitle)
                     {
                         toolbar.style.display = DisplayStyle.None;
                     }
@@ -675,7 +670,7 @@ namespace SaintsField.Editor.Playa.RendererGroup
             if (hasFoldout && !hasTitle && hasTab)
             {
                 // toolbar.Add(foldout);
-                ToolbarToggle foldoutToggle = new ToolbarToggle
+                foldoutToggle = new ToolbarToggle
                 {
                     value = true,
                     style =
@@ -694,10 +689,12 @@ namespace SaintsField.Editor.Playa.RendererGroup
                 foldoutToggle.Add(foldoutImage);
                 foldoutToggle.RegisterValueChangedCallback(evt =>
                 {
-                    foldoutAction(evt.newValue);
-                    foldoutImage.image = evt.newValue ? dropdownIcon : dropdownRightIcon;
+                    _foldout = evt.newValue;
+                    foldoutToggle.value = _foldout;
+                    foldoutAction(_foldout);
+                    foldoutImage.image = _foldout ? dropdownIcon : dropdownRightIcon;
                     
-                    if (!evt.newValue)
+                    if (!_foldout)
                     {
                         foreach (ToolbarToggle toolbarToggle in toolbarToggles)
                         {
@@ -715,7 +712,7 @@ namespace SaintsField.Editor.Playa.RendererGroup
                     {
                         if (evt.newValue)
                         {
-                            setTabToggle((foldoutToggle, true));
+                            foldoutToggle.value = true;
                         }
                     });
                 }
@@ -779,6 +776,7 @@ namespace SaintsField.Editor.Playa.RendererGroup
                 {
                     root.UnregisterCallback(switchOnAttack);
                     toolbarToggles[0].value = true;
+                    if (foldoutToggle != null) foldoutToggle.value = _foldout;
                 };
                 root.RegisterCallback(switchOnAttack);
             }

--- a/Editor/SaintsEditor.cs
+++ b/Editor/SaintsEditor.cs
@@ -449,7 +449,7 @@ namespace SaintsField.Editor
                 IReadOnlyList<ISaintsGroup> groups;
                 if (fieldWithInfosSorted[i].Groups.Count == 0 && previousGroupIndex != -1)
                 {
-                    groups = fieldInfosWithGroups.Count >= previousGroupIndex + 1
+                    groups = fieldInfosWithGroups.Count > previousGroupIndex
                         ? fieldInfosWithGroups[previousGroupIndex].Groups
                         : fieldWithInfosSorted[previousGroupIndex].Groups;
                 }

--- a/Runtime/Playa/DOTweenPlayAttribute.cs
+++ b/Runtime/Playa/DOTweenPlayAttribute.cs
@@ -16,13 +16,17 @@ namespace SaintsField.Playa
         public const string DOTweenPlayGroupBy = "__SAINTSFIELD_DOTWEEN_PLAY__";
         public string GroupBy { get; }
         public ELayout Layout => 0;
+        public bool GroupAllFieldsUntilNextGroupAttribute { get; }
+        public bool ClosedByDefault { get; }
 
-        public DOTweenPlayAttribute(string label = null, ETweenStop stopAction = ETweenStop.Rewind, string groupBy="")
+        public DOTweenPlayAttribute(string label = null, ETweenStop stopAction = ETweenStop.Rewind, string groupBy="", bool groupAllFieldsUntilNextGroupAttribute = false, bool closedByDefault = false)
         {
             Label = label;
             DOTweenStop = stopAction;
 
             GroupBy = string.IsNullOrEmpty(groupBy)? DOTweenPlayGroupBy: $"{groupBy}/{DOTweenPlayGroupBy}";
+            GroupAllFieldsUntilNextGroupAttribute = groupAllFieldsUntilNextGroupAttribute;
+            ClosedByDefault = closedByDefault;
         }
 
         public DOTweenPlayAttribute(ETweenStop stopAction, string groupBy=""): this(null, stopAction, groupBy)

--- a/Runtime/Playa/ISaintsGroup.cs
+++ b/Runtime/Playa/ISaintsGroup.cs
@@ -4,5 +4,7 @@
     {
         string GroupBy { get; }
         ELayout Layout { get; }
+        bool GroupAllFieldsUntilNextGroupAttribute { get; }
+        bool ClosedByDefault { get; }
     }
 }

--- a/Runtime/Playa/LayoutAttribute.cs
+++ b/Runtime/Playa/LayoutAttribute.cs
@@ -9,11 +9,15 @@ namespace SaintsField.Playa
     {
         public string GroupBy { get; }
         public ELayout Layout { get; }
+        public bool GroupAllFieldsUntilNextGroupAttribute { get; }
+        public bool ClosedByDefault { get; }
 
-        public LayoutAttribute(string groupBy, ELayout layout=0)
+        public LayoutAttribute(string groupBy, ELayout layout=0, bool groupAllFieldsUntilNextGroupAttribute = false, bool closedByDefault = false)
         {
             GroupBy = groupBy;
             Layout = layout;
+            GroupAllFieldsUntilNextGroupAttribute = groupAllFieldsUntilNextGroupAttribute;
+            ClosedByDefault = closedByDefault;
         }
     }
 }

--- a/Runtime/Playa/MarkPlayaMethodAttribute.cs
+++ b/Runtime/Playa/MarkPlayaMethodAttribute.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Diagnostics;
+
+namespace SaintsField.Playa
+{
+    [Conditional("UNITY_EDITOR")]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    public class MarkPlayaMethodAttribute : Attribute, IPlayaAttribute, IPlayaMethodAttribute
+    {
+    }
+}

--- a/Runtime/Playa/MarkPlayaMethodAttribute.cs.meta
+++ b/Runtime/Playa/MarkPlayaMethodAttribute.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: e1a3735184f6496fa8daaf5d246cbe65
+timeCreated: 1717963844

--- a/Samples~/Scripts/SaintsEditor/DOTweenExample.cs
+++ b/Samples~/Scripts/SaintsEditor/DOTweenExample.cs
@@ -15,8 +15,12 @@ namespace SaintsField.Samples.Scripts.SaintsEditor
         [Button("Tween under me")]
         private void Nothing1() {}
 
+        [Layout("Color", ELayout.Foldout | ELayout.Background| ELayout.Title | ELayout.TitleOut)]
+        [ReadOnly]
+        public string title = "This is Color Tween";
+
 #if DOTWEEN && !SAINTSFIELD_DOTWEEN_DISABLED
-        [DOTweenPlay]
+        [DOTweenPlay(groupBy: "Color", groupAllFieldsUntilNextGroupAttribute: true)]
         private Sequence PlayColor()
         {
             return DOTween.Sequence()
@@ -25,9 +29,19 @@ namespace SaintsField.Samples.Scripts.SaintsEditor
                 .Append(spriteRenderer.DOColor(Color.blue, 1f))
                 .SetLoops(-1);
         }
+        
+        [MarkPlayaMethod]
+        private Sequence PlayColor2()
+        {
+            return DOTween.Sequence()
+                .Append(spriteRenderer.DOColor(Color.cyan, 1f))
+                .Append(spriteRenderer.DOColor(Color.magenta, 1f))
+                .Append(spriteRenderer.DOColor(Color.yellow, 1f))
+                .SetLoops(-1);
+        }
 #endif
 
-        [Button("Tween above me")]
+        [Button("Tween above me"), Layout("")]
         private void Nothing2() {}
 
 #if DOTWEEN && !SAINTSFIELD_DOTWEEN_DISABLED

--- a/Samples~/Scripts/SaintsEditor/LayoutExample.cs
+++ b/Samples~/Scripts/SaintsEditor/LayoutExample.cs
@@ -20,8 +20,12 @@ namespace SaintsField.Samples.Scripts.SaintsEditor
         public string titledBoxItem2;
 
         // foldout
-        [Layout("Foldout", ELayout.Foldout)]
+        [Layout("Foldout", ELayout.Foldout | ELayout.Title | ELayout.Background | ELayout.TitleOut, true, true)]
         public string foldoutItem1, foldoutItem2;
+        public int foldoutItem3, foldoutItem4;
+        [Layout("Foldout/Tab1", ELayout.Foldout, true)]
+        public float foldoutItem5, foldoutItem6;
+        public string foldoutItem7, foldoutItem8;
 
         // tabs
         [Layout("Tabs", ELayout.Tab | ELayout.Foldout)]

--- a/Samples~/Scripts/SaintsEditor/LayoutExample.cs
+++ b/Samples~/Scripts/SaintsEditor/LayoutExample.cs
@@ -28,7 +28,7 @@ namespace SaintsField.Samples.Scripts.SaintsEditor
         public string foldoutItem7, foldoutItem8;
 
         // tabs
-        [Layout("Tabs", ELayout.Tab | ELayout.Foldout)]
+        [Layout("Tabs", ELayout.Tab | ELayout.Foldout, closedByDefault: true)]
         [Layout("Tabs/Tab1")]
         public string tab1Item1, tab1Item2;
 


### PR DESCRIPTION
- groupAllFieldsUntilNextGroupAttribute: It is now possible to add multiple different types of fields to the same Foldout by adding properties once
- closedByDefault: Foldout's default state
- add a simple attribute to mark the method as PlayaMethod