### PR TITLE
fixed And/Or complex mode in DisabledDrawers and VisibilityDrawers with EMode

### DIFF
--- a/Editor/Core/SaintsPropertyDrawer.cs
+++ b/Editor/Core/SaintsPropertyDrawer.cs
@@ -256,8 +256,7 @@ namespace SaintsField.Editor.Core
 
         private float _labelFieldBasicHeight = EditorGUIUtility.singleLineHeight;
 
-        protected virtual bool GetAndVisibility(SerializedProperty property,
-            ISaintsAttribute saintsAttribute, FieldInfo info, object parent)
+        protected virtual bool GetAndVisibility(SerializedProperty property, FieldInfo info, object parent)
         {
             return true;
         }
@@ -267,10 +266,10 @@ namespace SaintsField.Editor.Core
             List<bool> showAndResults = new List<bool>();
             foreach (SaintsWithIndex saintsAttributeWithIndex in saintsAttributeWithIndexes)
             {
-                if(saintsAttributeWithIndex.SaintsAttribute is IImGuiVisibilityAttribute)
+                if (saintsAttributeWithIndex.SaintsAttribute is IImGuiVisibilityAttribute)
                 {
                     SaintsPropertyDrawer drawer = GetOrCreateSaintsDrawer(saintsAttributeWithIndex);
-                    showAndResults.Add(drawer.GetAndVisibility(property, saintsAttributeWithIndex.SaintsAttribute, fieldInfo, parent));
+                    showAndResults.Add(drawer.GetAndVisibility(property, fieldInfo, parent));
                 }
             }
             // Debug.Log($"visibility={string.Join(", ", showAndResults)}");

--- a/Editor/Drawers/DisabledDrawers/EnableIfAttributeDrawer.cs
+++ b/Editor/Drawers/DisabledDrawers/EnableIfAttributeDrawer.cs
@@ -1,7 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using SaintsField.Editor.Utils;
+﻿using System.Reflection;
 using UnityEditor;
 
 namespace SaintsField.Editor.Drawers.DisabledDrawers
@@ -9,29 +6,10 @@ namespace SaintsField.Editor.Drawers.DisabledDrawers
     [CustomPropertyDrawer(typeof(EnableIfAttribute))]
     public class EnableIfAttributeDrawer: ReadOnlyAttributeDrawer
     {
-        protected override (string error, bool disabled) IsDisabled(SerializedProperty property,
-            ISaintsAttribute saintsAttribute, FieldInfo info, object target)
+        protected override (string error, bool disabled) IsDisabled(SerializedProperty property, FieldInfo info, object target)
         {
-            EnableIfAttribute targetAttribute = (EnableIfAttribute) saintsAttribute;
-
-            bool editorModeOk = Util.ConditionEditModeChecker(targetAttribute.EditorMode);
-            if (!editorModeOk)
-            {
-                return ("", false);
-            }
-
-            (IReadOnlyList<string> errors, IReadOnlyList<bool> boolResults) = Util.ConditionChecker(targetAttribute.ConditionInfos, property, info, target);
-
-            if (errors.Count > 0)
-            {
-                return (string.Join("\n\n", errors), false);
-            }
-
-            // or, get enabled
-            bool truly = boolResults.Any(each => each);
-
             // reverse, get disabled
-            return ("", !truly);
+            return ("", !base.IsDisabled(property, info, target).disabled);
         }
     }
 }

--- a/Editor/Drawers/VisibilityDrawers/HideIfAttributeDrawer.cs
+++ b/Editor/Drawers/VisibilityDrawers/HideIfAttributeDrawer.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using SaintsField.Editor.Utils;
+﻿using System.Reflection;
 using UnityEditor;
 
 namespace SaintsField.Editor.Drawers.VisibilityDrawers
@@ -10,37 +6,10 @@ namespace SaintsField.Editor.Drawers.VisibilityDrawers
     [CustomPropertyDrawer(typeof(HideIfAttribute))]
     public class HideIfAttributeDrawer: ShowIfAttributeDrawer
     {
-        protected override (string error, bool shown) IsShown(SerializedProperty property,
-            ISaintsAttribute saintsAttribute, FieldInfo info,
-            Type type, object target)
+        protected override (string error, bool shown) IsShown(SerializedProperty property,  FieldInfo info, object target)
         {
-            HideIfAttribute hideIfAttribute = (HideIfAttribute)saintsAttribute;
-
-            bool editorModeOk = Util.ConditionEditModeChecker(hideIfAttribute.EditorMode);
-            if (!editorModeOk)
-            {
-                return ("", false);
-            }
-
-            (IReadOnlyList<string> errors, IReadOnlyList<bool> boolResults) = Util.ConditionChecker(hideIfAttribute.ConditionInfos, property, info, target);
-
-            if (errors.Count > 0)
-            {
-                return (string.Join("\n\n", errors), true);
-            }
-
-            // or, get hide
-            // any(empty) = false, reversed=show(true)
-            // we need to manually deal the empty
-            if(boolResults.Count == 0)
-            {
-                return ("", false);  // don't show if empty
-            }
-
-            bool truly = boolResults.Any(each => each);
-
             // reverse, get shown
-            return ("", !truly);
+            return ("", !base.IsShown(property, info, target).shown);
         }
     }
 }

--- a/Editor/Drawers/VisibilityDrawers/ShowIfAttributeDrawer.cs
+++ b/Editor/Drawers/VisibilityDrawers/ShowIfAttributeDrawer.cs
@@ -1,38 +1,40 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using SaintsField.Editor.Utils;
 using UnityEditor;
-using UnityEngine;
 
 namespace SaintsField.Editor.Drawers.VisibilityDrawers
 {
     [CustomPropertyDrawer(typeof(ShowIfAttribute))]
     public class ShowIfAttributeDrawer: VisibilityAttributeDrawer
     {
-        // and
-        protected override (string error, bool shown) IsShown(SerializedProperty property, ISaintsAttribute saintsAttribute, FieldInfo info,
-            Type type, object target)
+        protected override (string error, bool shown) IsShown(SerializedProperty property, FieldInfo info, object target)
         {
-            ShowIfAttribute showIfAttribute = (ShowIfAttribute)saintsAttribute;
-
-            bool editorModeOk = Util.ConditionEditModeChecker(showIfAttribute.EditorMode);
-            if (!editorModeOk)
+            List<bool> allResults = new List<bool>();
+           
+            ShowIfAttribute[] targetAttributes = SerializedUtils.GetAttributesAndDirectParent<ShowIfAttribute>(property).attributes;
+            foreach (var targetAttribute in targetAttributes)
             {
-                return ("", false);
+                (IReadOnlyList<string> errors, IReadOnlyList<bool> boolResults) = Util.ConditionChecker(targetAttribute.ConditionInfos, property, info, target);
+
+                if (errors.Count > 0)
+                {
+                    return (string.Join("\n\n", errors), false);
+                }
+                
+                bool editorModeOk = Util.ConditionEditModeChecker(targetAttribute.EditorMode);
+                // empty = true
+                bool boolResultsOk = boolResults.All(each => each);
+                allResults.Add(editorModeOk && boolResultsOk);
             }
+            
+            // Or/And Mode
+            bool truly = targetAttributes.Length > 1 ? allResults.Any(each => each) : allResults.All(each => each);
 
-            (IReadOnlyList<string> errors, IReadOnlyList<bool> boolResults) = Util.ConditionChecker(showIfAttribute.ConditionInfos, property, info, target);
-
-            if (errors.Count > 0)
-            {
-                return (string.Join("\n\n", errors), true);
-            }
-
-            // empty = true
-            bool truly = boolResults.All(each => each);
-
+#if SAINTSFIELD_DEBUG && SAINTSFIELD_DEBUG_READ_ONLY
+            UnityEngine.Debug.Log($"{property.name} final={truly}/ars={string.Join(",", allResults)}");
+#endif
             return ("", truly);
         }
     }

--- a/Editor/Drawers/VisibilityDrawers/ShowIfAttributeDrawer.cs
+++ b/Editor/Drawers/VisibilityDrawers/ShowIfAttributeDrawer.cs
@@ -20,7 +20,7 @@ namespace SaintsField.Editor.Drawers.VisibilityDrawers
 
                 if (errors.Count > 0)
                 {
-                    return (string.Join("\n\n", errors), false);
+                    return (string.Join("\n\n", errors), true);
                 }
                 
                 bool editorModeOk = Util.ConditionEditModeChecker(targetAttribute.EditorMode);

--- a/Editor/Drawers/VisibilityDrawers/VisibilityAttributeDrawer.cs
+++ b/Editor/Drawers/VisibilityDrawers/VisibilityAttributeDrawer.cs
@@ -10,26 +10,18 @@ using UnityEngine.UIElements;
 
 namespace SaintsField.Editor.Drawers.VisibilityDrawers
 {
-    // [CustomPropertyDrawer(typeof(VisibilityAttribute))]
-    // [CustomPropertyDrawer(typeof(ShowIfAttribute))]
-    // [CustomPropertyDrawer(typeof(HideIfAttribute))]
     public abstract class VisibilityAttributeDrawer: SaintsPropertyDrawer
     {
         #region IMGUI
-        protected override bool GetAndVisibility(SerializedProperty property,
-            ISaintsAttribute saintsAttribute, FieldInfo info, object parent)
+        protected override bool GetAndVisibility(SerializedProperty property, FieldInfo info, object parent)
         {
-            // VisibilityAttribute visibilityAttribute = (VisibilityAttribute)saintsAttribute;
-            Type type = parent.GetType();
-
-            (string error, bool show) = IsShown(property, saintsAttribute, info, type, parent);
+            (string error, bool show) = IsShown(property, info, parent);
 
             _error = error;
             return show;
         }
 
-        protected abstract (string error, bool shown) IsShown(SerializedProperty property,
-            ISaintsAttribute visibilityAttribute, FieldInfo info, Type type, object target);
+        protected abstract (string error, bool shown) IsShown(SerializedProperty property, FieldInfo info, object target);
 
         private string _error = "";
 
@@ -132,7 +124,7 @@ namespace SaintsField.Editor.Drawers.VisibilityDrawers
             // bool isForHidden = ((VisibilityAttribute)saintsAttribute).IsForHide;
             object parent = SerializedUtils.GetFieldInfoAndDirectParent(property).parent;
 
-            foreach ((string error, bool show) in visibilityElements.Select(each => IsShown(property, (ISaintsAttribute)each.userData, info, parent.GetType(), parent)))
+            foreach ((string error, bool show) in visibilityElements.Select(each => IsShown(property, info, parent)))
             {
                 // bool invertedShow = isForHidden? !show: show;
 

--- a/Samples~/Scripts/IssueAndTesting/Issue/Issue4/Editor/DisabledIfPlayAttributeDrawer.cs
+++ b/Samples~/Scripts/IssueAndTesting/Issue/Issue4/Editor/DisabledIfPlayAttributeDrawer.cs
@@ -8,7 +8,7 @@ namespace SaintsField.Samples.Scripts.IssueAndTesting.Issue.Issue4.Editor
     [CustomPropertyDrawer(typeof(DisabledIfPlayAttribute))]
     public class DisabledIfPlayAttributeDrawer: ReadOnlyAttributeDrawer
     {
-        protected override (string error, bool disabled) IsDisabled(SerializedProperty property, ISaintsAttribute targetAttribute, FieldInfo info, object target)
+        protected override (string error, bool disabled) IsDisabled(SerializedProperty property, FieldInfo info, object target)
         {
             return ("", EditorApplication.isPlaying);
         }

--- a/Samples~/Scripts/IssueAndTesting/Issue/Issue4/Editor/ShowIfPlayAttributeDrawer.cs
+++ b/Samples~/Scripts/IssueAndTesting/Issue/Issue4/Editor/ShowIfPlayAttributeDrawer.cs
@@ -9,8 +9,7 @@ namespace SaintsField.Samples.Scripts.IssueAndTesting.Issue.Issue4.Editor
     [CustomPropertyDrawer(typeof(ShowIfPlayAttribute))]
     public class ShowIfPlayAttributeDrawer: VisibilityAttributeDrawer
     {
-        protected override (string error, bool shown) IsShown(SerializedProperty property, ISaintsAttribute visibilityAttribute, FieldInfo info,
-            Type type, object target)
+        protected override (string error, bool shown) IsShown(SerializedProperty property, FieldInfo info, object target)
         {
             return ("", EditorApplication.isPlaying);
         }

--- a/Samples~/Scripts/ReadOnlyExamples/EnableIfExample.cs
+++ b/Samples~/Scripts/ReadOnlyExamples/EnableIfExample.cs
@@ -11,8 +11,8 @@ namespace SaintsField.Samples.Scripts.ReadOnlyExamples
 
         [EnableIf(nameof(bool1))] public string e1;
 
-        [EnableIf(nameof(bool1), nameof(bool2))] public string e1Or2;
+        [EnableIf(nameof(bool1), nameof(bool2))] public string e1And2;
 
-        [EnableIf(nameof(bool1)), EnableIf(nameof(bool2))] public string e1And2;
+        [EnableIf(nameof(bool1)), EnableIf(nameof(bool2))] public string e1Or2;
     }
 }

--- a/Samples~/Scripts/ReadOnlyExamples/EnableModeExample.cs
+++ b/Samples~/Scripts/ReadOnlyExamples/EnableModeExample.cs
@@ -9,8 +9,8 @@ namespace SaintsField.Samples.Scripts.ReadOnlyExamples
         [EnableIf(EMode.Edit)] public string enEditMode;
         [EnableIf(EMode.Play)] public string enPlayMode;
 
-        [EnableIf(EMode.Edit, nameof(boolVal))] public string enEditOrBool;
+        [EnableIf(EMode.Edit, nameof(boolVal))] public string enEditAndBool;
         // dis=!editor || dis=!bool => en=editor&&bool
-        [EnableIf(EMode.Edit), EnableIf(nameof(boolVal))] public string enEditAndBool;
+        [EnableIf(EMode.Edit), EnableIf(nameof(boolVal))] public string enEditOrBool;
     }
 }

--- a/Samples~/Scripts/ShowHideExamples/HideIfExample.cs
+++ b/Samples~/Scripts/ShowHideExamples/HideIfExample.cs
@@ -7,9 +7,9 @@ namespace SaintsField.Samples.Scripts.ShowHideExamples
         public bool bool1;
         public bool bool2;
         // hide=1||2 => show=!(1||2)=!1&&!2;
-        [HideIf(nameof(bool1), nameof(bool2))] public string hide1Or2;
+        [HideIf(nameof(bool1), nameof(bool2))] public string hide1And2;
 
         // hide=1||hide=2 => show=!1||show=!2 => show=!1||!2 => show=!(1&&2);
-        [HideIf(nameof(bool1)), HideIf(nameof(bool2))] public string hideNotBoth1And2;
+        [HideIf(nameof(bool1)), HideIf(nameof(bool2))] public string hide1Or2;
     }
 }

--- a/Samples~/Scripts/ShowHideExamples/HideModeExample.cs
+++ b/Samples~/Scripts/ShowHideExamples/HideModeExample.cs
@@ -9,7 +9,7 @@ namespace SaintsField.Samples.Scripts.ShowHideExamples
         [HideIf(EMode.Edit)] public string hideEdit;
         [HideIf(EMode.Play)] public string hidePlay;
 
-        [HideIf(EMode.Edit, nameof(boolValue))] public string hideEditOrBool;
-        [HideIf(EMode.Edit), HideIf(nameof(boolValue))] public string hideEditAndBool;
+        [HideIf(EMode.Edit), HideIf(nameof(boolValue))] public string hideEditOrBool;
+        [HideIf(EMode.Edit, nameof(boolValue))] public string hideEditAndBool;
     }
 }


### PR DESCRIPTION
When we put together the EMode and params, DisabledDrawers and VisibilityDrawers didn't show it right.
![image](https://github.com/user-attachments/assets/fb709d6c-5ce4-409a-9576-c73ae8d144b6)

[Fixed]
When we use one attrbute, it means And, and multiple means Or.
![image](https://github.com/user-attachments/assets/75de6aa3-fd1a-4995-a6d6-e76ec73d23a4)

[Editor]
![image](https://github.com/user-attachments/assets/3b9ec8f7-9e7a-4c81-b292-1619a15af6c0)
[Play]
![image](https://github.com/user-attachments/assets/8a810767-3d88-4517-97d7-e67b4d45b8f0)

