### PR TITLE
Add support for byte/sbyte fields

### DIFF
--- a/Editor/Playa/Renderer/BaseRenderer/AbsRendererIMGUI.cs
+++ b/Editor/Playa/Renderer/BaseRenderer/AbsRendererIMGUI.cs
@@ -567,6 +567,8 @@ namespace SaintsField.Editor.Playa.Renderer.BaseRenderer
             Type valueType = value.GetType();
 
             if (valueType == typeof(bool)
+                || valueType == typeof(sbyte)
+                || valueType == typeof(byte)
                 || valueType == typeof(short)
                 || valueType == typeof(ushort)
                 || valueType == typeof(int)
@@ -682,6 +684,14 @@ namespace SaintsField.Editor.Playa.Renderer.BaseRenderer
                     return EditorGUI.Toggle(position, label, (bool)value);
                 }
 
+                if (valueType == typeof(sbyte))
+                {
+                    return EditorGUI.IntField(position, label, (sbyte)value);
+                }
+                if (valueType == typeof(byte))
+                {
+                    return EditorGUI.IntField(position, label, (byte)value);
+                }
                 if (valueType == typeof(short))
                 {
                     return EditorGUI.IntField(position, label, (short)value);

--- a/Editor/Playa/Renderer/BaseRenderer/AbsRendererUIToolkit.cs
+++ b/Editor/Playa/Renderer/BaseRenderer/AbsRendererUIToolkit.cs
@@ -430,6 +430,22 @@ namespace SaintsField.Editor.Playa.Renderer.BaseRenderer
                 });
             }
 
+            if (valueType == typeof(sbyte))
+            {
+                // EditorGUILayout.IntField(label, (sbyte)value);
+                return WrapVisualElement(new IntegerField(label)
+                {
+                    value = (sbyte)value,
+                });
+            }
+            if (valueType == typeof(byte))
+            {
+                // EditorGUILayout.IntField(label, (byte)value);
+                return WrapVisualElement(new IntegerField(label)
+                {
+                    value = (byte)value,
+                });
+            }
             if (valueType == typeof(short))
             {
                 // EditorGUILayout.IntField(label, (short)value);


### PR DESCRIPTION
As the title says. Tested in Unity 2019.1.0 with IMGUI and Unity 2022.3.57 with UIToolkit.