### PR TITLE
Suppress all compiler warnings caused by preprocessors

### DIFF
--- a/Editor/AutoRunner/AutoRunnerWindowBase.cs
+++ b/Editor/AutoRunner/AutoRunnerWindowBase.cs
@@ -67,7 +67,9 @@ namespace SaintsField.Editor.AutoRunner
                 {
                     so = new SerializedObject(obj);
                 }
+#pragma warning disable CS0168 
                 catch (Exception e)
+#pragma warning restore CS0168 
                 {
 #if SAINTSFIELD_DEBUG
                     Debug.Log($"#AutoRunner# Skip {obj} as it's not a valid object: {e}");
@@ -102,7 +104,9 @@ namespace SaintsField.Editor.AutoRunner
                     {
                         so = new SerializedObject(comp);
                     }
+#pragma warning disable CS0168 
                     catch (Exception e)
+#pragma warning restore CS0168 
                     {
 #if SAINTSFIELD_DEBUG
                         Debug.Log($"#AutoRunner# Skip {comp} as it's not a valid object: {e}");
@@ -243,7 +247,9 @@ namespace SaintsField.Editor.AutoRunner
                     {
                         so = new SerializedObject(extra);
                     }
+#pragma warning disable CS0168 
                     catch (Exception e)
+#pragma warning restore CS0168 
                     {
 #if SAINTSFIELD_DEBUG
                         Debug.Log($"#AutoRunner# Skip {extra} as it's not a valid object: {e}");

--- a/Editor/Core/RichTextDrawer.cs
+++ b/Editor/Core/RichTextDrawer.cs
@@ -379,7 +379,9 @@ namespace SaintsField.Editor.Core
                                             {
                                                 tagFinalResult = string.Format(formatString, finalValue);
                                             }
+#pragma warning disable CS0168 
                                             catch (Exception ex)
+#pragma warning restore CS0168 
                                             {
 #if SAINTSFIELD_DEBUG
                                                 Debug.LogException(ex);

--- a/Editor/Drawers/AdvancedDropdownDrawer/AdvancedDropdownAttributeDrawerIMGUI.cs
+++ b/Editor/Drawers/AdvancedDropdownDrawer/AdvancedDropdownAttributeDrawerIMGUI.cs
@@ -60,11 +60,15 @@ namespace SaintsField.Editor.Drawers.AdvancedDropdownDrawer
             // ReSharper disable once InvertIf
             if (EditorGUI.DropdownButton(leftRect, new GUIContent(display), FocusType.Keyboard))
             {
+#pragma warning disable CS0219
                 float minHeight = AdvancedDropdownAttribute.MinHeight;
+#pragma warning restore CS0219
                 float itemHeight = AdvancedDropdownAttribute.ItemHeight > 0
                     ? AdvancedDropdownAttribute.ItemHeight
                     : EditorGUIUtility.singleLineHeight;
+#pragma warning disable CS0219
                 float titleHeight = AdvancedDropdownAttribute.TitleHeight;
+#pragma warning restore CS0219
                 // Vector2 size;
                 // if (minHeight < 0)
                 // {

--- a/Editor/Drawers/SceneDrawer/SceneAttributeDrawerIMGUI.cs
+++ b/Editor/Drawers/SceneDrawer/SceneAttributeDrawerIMGUI.cs
@@ -155,11 +155,15 @@ namespace SaintsField.Editor.Drawers.SceneDrawer
 
             if (EditorGUI.DropdownButton(leftRect, new GUIContent(display), FocusType.Keyboard))
             {
+#pragma warning disable CS0219
                 float minHeight = AdvancedDropdownAttribute.MinHeight;
+#pragma warning restore CS0219
                 float itemHeight = AdvancedDropdownAttribute.ItemHeight > 0
                     ? AdvancedDropdownAttribute.ItemHeight
                     : EditorGUIUtility.singleLineHeight;
+#pragma warning disable CS0219
                 float titleHeight = AdvancedDropdownAttribute.TitleHeight;
+#pragma warning restore CS0219
                 Vector2 size = AdvancedDropdownUtil.GetSizeIMGUI(metaInfo.DropdownListValue, position.width);
 
                 // OnGUIPayload targetPayload = onGUIPayload;

--- a/Editor/Drawers/XPathDrawers/GetByXPathDrawer/GetByXPathAttributeDrawer.cs
+++ b/Editor/Drawers/XPathDrawers/GetByXPathDrawer/GetByXPathAttributeDrawer.cs
@@ -459,14 +459,18 @@ namespace SaintsField.Editor.Drawers.XPathDrawers.GetByXPathDrawer
             {
                 string _ = propertyCache.SerializedProperty.propertyPath;
             }
+#pragma warning disable CS0168 
             catch (NullReferenceException e)
+#pragma warning restore CS0168 
             {
 #if SAINTSFIELD_DEBUG
                 Debug.LogException(e);
 #endif
                 return false;
             }
+#pragma warning disable CS0168 
             catch (ObjectDisposedException e)
+#pragma warning restore CS0168 
             {
 #if SAINTSFIELD_DEBUG
                 Debug.LogException(e);
@@ -623,7 +627,9 @@ namespace SaintsField.Editor.Drawers.XPathDrawers.GetByXPathDrawer
                         processingProperty =
                             target.ArrayProperty.GetArrayElementAtIndex(propertyCacheKey);
                     }
+#pragma warning disable CS0168 
                     catch (NullReferenceException e)
+#pragma warning restore CS0168 
                     {
 #if SAINTSFIELD_DEBUG
                         Debug.LogException(e);

--- a/Editor/Drawers/XPathDrawers/GetByXPathDrawer/GetByXPathAttributeDrawerIMGUI.cs
+++ b/Editor/Drawers/XPathDrawers/GetByXPathDrawer/GetByXPathAttributeDrawerIMGUI.cs
@@ -73,7 +73,9 @@ namespace SaintsField.Editor.Drawers.XPathDrawers.GetByXPathDrawer
             {
                 arrayRemovedKey = SerializedUtils.GetUniqueIdArray(property);
             }
+#pragma warning disable CS0168 
             catch (ObjectDisposedException e)
+#pragma warning restore CS0168 
             {
 #if SAINTSFIELD_DEBUG
                 Debug.LogException(e);
@@ -81,7 +83,9 @@ namespace SaintsField.Editor.Drawers.XPathDrawers.GetByXPathDrawer
 
                 return 0;
             }
+#pragma warning disable CS0168 
             catch (NullReferenceException e)
+#pragma warning restore CS0168 
             {
 #if SAINTSFIELD_DEBUG
                 Debug.LogException(e);

--- a/Editor/Drawers/XPathDrawers/GetByXPathDrawer/GetByXPathAttributeDrawerTargetGetter.cs
+++ b/Editor/Drawers/XPathDrawers/GetByXPathDrawer/GetByXPathAttributeDrawerTargetGetter.cs
@@ -163,9 +163,9 @@ namespace SaintsField.Editor.Drawers.XPathDrawers.GetByXPathDrawer
                                 {
                                     return AssetDatabase.LoadAssetAtPath<Object>(assetPath);
                                 }
-#pragma warning disable CS0168 // Variable is declared but never used
+#pragma warning disable CS0168 
                                 catch (Exception e)
-#pragma warning restore CS0168 // Variable is declared but never used
+#pragma warning restore CS0168 
                                 {
 #if SAINTSFIELD_DEBUG
                                     Debug.LogException(e);

--- a/Editor/Playa/Renderer/BaseRenderer/AbsRendererUIToolkit.cs
+++ b/Editor/Playa/Renderer/BaseRenderer/AbsRendererUIToolkit.cs
@@ -747,9 +747,9 @@ namespace SaintsField.Editor.Playa.Renderer.BaseRenderer
                 {
                     fieldValue = fieldInfo.GetValue(value);
                 }
-#pragma warning disable CS0168 // Variable is declared but never used
+#pragma warning disable CS0168 
                 catch (NullReferenceException e)
-#pragma warning restore CS0168 // Variable is declared but never used
+#pragma warning restore CS0168 
                 {
 #if SAINTSFIELD_DEBUG
                     Debug.LogException(e);
@@ -766,7 +766,9 @@ namespace SaintsField.Editor.Playa.Renderer.BaseRenderer
                 {
                     propertyValue = propertyInfo.GetValue(value);
                 }
+#pragma warning disable CS0168
                 catch (NullReferenceException e)
+#pragma warning restore CS0168
                 {
 #if SAINTSFIELD_DEBUG
                     Debug.LogException(e);

--- a/Editor/TroubleshootEditor/TroubleshootEditorWindow.cs
+++ b/Editor/TroubleshootEditor/TroubleshootEditorWindow.cs
@@ -335,8 +335,10 @@ namespace SaintsField.Editor.TroubleshootEditor
             return result;
         }
 
+#pragma warning disable CS0414
         private (EMessageType, string) _targetMessage = (EMessageType.Warning, null);
         private (EMessageType, string) _fieldMessage = (EMessageType.Warning, null);
+#pragma warning restore CS0414
 
         // [Ordered, ]
         private void RunTargetChecker(int index)

--- a/Editor/Utils/ObjectSelectWindow.cs
+++ b/Editor/Utils/ObjectSelectWindow.cs
@@ -670,7 +670,9 @@ namespace SaintsField.Editor.Utils
                 {
                     go = property.pptrValue;
                 }
+#pragma warning disable CS0168 
                 catch (Exception e)
+#pragma warning restore CS0168 
                 {
 #if SAINTSFIELD_DEBUG
                     Debug.LogException(e);

--- a/Runtime/Utils/SaintsFieldConfigUtil.cs
+++ b/Runtime/Utils/SaintsFieldConfigUtil.cs
@@ -10,7 +10,9 @@ namespace SaintsField.Utils
 
 #if UNITY_EDITOR
     [InitializeOnLoad]
+#pragma warning disable CS0618
     public class SaintsFieldConfigDeleteWatcher : AssetModificationProcessor
+#pragma warning restore CS0618
     {
         // ReSharper disable once EmptyConstructor
         static SaintsFieldConfigDeleteWatcher()
@@ -68,7 +70,9 @@ namespace SaintsField.Utils
             {
                 Config = (SaintsFieldConfig)EditorGUIUtility.Load(EditorResourcePath);
             }
+#pragma warning disable CS0168
             catch (Exception e)
+#pragma warning restore CS0168
             {
                 // do nothing
 #if SAINTSFIELD_DEBUG


### PR DESCRIPTION
This uses #pragma to suppress all compiler warnings caused by other preprocessors. I've suppressed all warnings I could find with Unity 2019 and Unity 2021 with SaintsEditor both enabled and disabled, so this should be most of them but there may be a few left that appear with different configurations.

Closes #165 