### PR TITLE
Add the MeansImplicitUse attribute to the Button attribute

### DIFF
--- a/Runtime/Playa/ButtonAttribute.cs
+++ b/Runtime/Playa/ButtonAttribute.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using System.Diagnostics;
+using JetBrains.Annotations;
 using SaintsField.Utils;
 
 namespace SaintsField.Playa
 {
+    [MeansImplicitUse]
     [Conditional("UNITY_EDITOR")]
     [AttributeUsage(AttributeTargets.Method)]
     public class ButtonAttribute: Attribute, IPlayaAttribute, IPlayaMethodAttribute


### PR DESCRIPTION
This attribute tells ReSharper/Rider not to show the method as unused. The attribute is always available regardless of whether the JetBrains package is installed, tested in Unity 2019.1.0 and Unity 2022.3.5.

I don't know SaintsField well enough yet to know if other attributes should get this, but I didn't see any from a quick search.

**Before**
![image](https://github.com/user-attachments/assets/9fc46295-1cc2-48ca-a227-13c4fef2a4b8)

**After:**
![image](https://github.com/user-attachments/assets/9717c71a-b7c7-4790-8e14-6b712618f672)
