### PR TITLE
Remove the SAINTSFIELD_JETBRAINS_RIDER define

### DIFF
--- a/Runtime/Playa/ButtonAttribute.cs
+++ b/Runtime/Playa/ButtonAttribute.cs
@@ -1,16 +1,11 @@
 ﻿using System;
 using System.Diagnostics;
-using SaintsField.Utils;
-#if SAINTSFIELD_JETBRAINS_RIDER
 using JetBrains.Annotations;
-#endif
-
+using SaintsField.Utils;
 
 namespace SaintsField.Playa
 {
-#if SAINTSFIELD_JETBRAINS_RIDER
     [MeansImplicitUse]
-#endif
     [Conditional("UNITY_EDITOR")]
     [AttributeUsage(AttributeTargets.Method)]
     public class ButtonAttribute: Attribute, IPlayaAttribute, IPlayaMethodAttribute

--- a/Runtime/today.comes.saintsfield.Runtime.asmdef
+++ b/Runtime/today.comes.saintsfield.Runtime.asmdef
@@ -31,11 +31,6 @@
             "name": "today.comes.saintsdraw",
             "expression": "1.0.4",
             "define": "SAINTSFIELD_SAINTSDRAW"
-        },
-        {
-            "name": "com.unity.ide.rider",
-            "expression": "",
-            "define": "SAINTSFIELD_JETBRAINS_RIDER"
         }
     ],
     "noEngineReferences": false


### PR DESCRIPTION
In https://github.com/TylerTemp/SaintsField/commit/004c147942287554ec3166f6f12184c9eee5c8b2 and https://github.com/TylerTemp/SaintsField/commit/47d2bc57f05ab9e97b143a0234c87f8fc0af0466, the `SAINTSFIELD_JETBRAINS_RIDER` define was added around the references to JetBrains annotations when the Rider package is installed.

JetBrains Annotations has been embedded directly in `UnityEngine.dll`/`UnityEngine.CoreModule.dll` since Unity 5, so it's *always* available. With all packages removed, I verified this in Unity 2019.1.0, Unity 2022.3.57, and Unity 6000.0.42.
![image](https://github.com/user-attachments/assets/74df3da7-b721-4460-b5ca-5dcd59771329)

These attributes also affect more than just Rider (although that's the most common case); they also affect the [ReSharper](https://www.jetbrains.com/resharper/) extension for Visual Studio, which people may be using without the JetBrains package installed.