### PR TITLE
Cache MemberInfo attributes and other misc optimizations

### DIFF
--- a/Editor/AutoRunner/AutoRunnerWindowBase.cs
+++ b/Editor/AutoRunner/AutoRunnerWindowBase.cs
@@ -344,9 +344,7 @@ namespace SaintsField.Editor.AutoRunner
                             ? (MemberInfo)info.fieldOrProp.FieldInfo
                             : info.fieldOrProp.PropertyInfo;
 
-                        PropertyAttribute[] allProperties = memberInfo.GetCustomAttributes()
-                            .OfType<PropertyAttribute>()
-                            .ToArray();
+                        PropertyAttribute[] allProperties = memberInfo.GetCustomAttributesFast<PropertyAttribute>();
 
                         PropertyAttribute[] saintsAttribute = allProperties
                             .Where(each => each is ISaintsAttribute)

--- a/Editor/AutoRunner/AutoRunnerWindowBase.cs
+++ b/Editor/AutoRunner/AutoRunnerWindowBase.cs
@@ -344,7 +344,7 @@ namespace SaintsField.Editor.AutoRunner
                             ? (MemberInfo)info.fieldOrProp.FieldInfo
                             : info.fieldOrProp.PropertyInfo;
 
-                        PropertyAttribute[] allProperties = memberInfo.GetCustomAttributesFast<PropertyAttribute>();
+                        PropertyAttribute[] allProperties = ReflectCache.GetCustomAttributes<PropertyAttribute>(memberInfo);
 
                         PropertyAttribute[] saintsAttribute = allProperties
                             .Where(each => each is ISaintsAttribute)

--- a/Editor/Core/InsideSaintsFieldScoop.cs
+++ b/Editor/Core/InsideSaintsFieldScoop.cs
@@ -8,10 +8,16 @@ namespace SaintsField.Editor.Core
 {
     public class InsideSaintsFieldScoop: IDisposable
     {
-        public struct PropertyKey : IEquatable<PropertyKey>
+        public readonly struct PropertyKey : IEquatable<PropertyKey>
         {
-            public int ObjectHash;
-            public string PropertyPath;
+            public readonly int ObjectHash;
+            public readonly string PropertyPath;
+
+            public PropertyKey(int objectHash, string propertyPath)
+            {
+                ObjectHash = objectHash;
+                PropertyPath = propertyPath;
+            }
 
             public override string ToString()
             {
@@ -36,11 +42,10 @@ namespace SaintsField.Editor.Core
 
         private readonly PropertyKey _property;
 
-        public static PropertyKey MakeKey(SerializedProperty property) => new PropertyKey
-        {
-            ObjectHash = property.serializedObject.targetObject.GetInstanceID(),
-            PropertyPath = property.propertyPath,
-        };
+        public static PropertyKey MakeKey(SerializedProperty property) => new PropertyKey(
+            property.serializedObject.targetObject.GetInstanceID(),
+            property.propertyPath
+        );
 
         private readonly Dictionary<InsideSaintsFieldScoop.PropertyKey, int> Counter;
 

--- a/Editor/Core/InsideSaintsFieldScoop.cs
+++ b/Editor/Core/InsideSaintsFieldScoop.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 
 namespace SaintsField.Editor.Core
 {
-    public class InsideSaintsFieldScoop: IDisposable
+    public readonly struct InsideSaintsFieldScoop: IDisposable
     {
         public readonly struct PropertyKey : IEquatable<PropertyKey>
         {

--- a/Editor/Core/RichTextDrawer.cs
+++ b/Editor/Core/RichTextDrawer.cs
@@ -321,13 +321,19 @@ namespace SaintsField.Editor.Core
                                             string[] subFields = parsedResult.content.Substring("field.".Length).Split(SerializedUtils.pathSplitSeparator);
                                             foreach (string attrName in subFields)
                                             {
-                                                MemberInfo accMemberInfo = ReflectUtils.GetSelfAndBaseTypes(accParent)
-                                                    .SelectMany(type => type
-                                                        .GetMember(attrName,
-                                                            BindingFlags.Public | BindingFlags.NonPublic |
-                                                            BindingFlags.Instance | BindingFlags.Static |
-                                                            BindingFlags.FlattenHierarchy))
-                                                    .FirstOrDefault(each => each != null);
+                                                MemberInfo accMemberInfo = null;
+                                                foreach (var type in ReflectUtils.GetSelfAndBaseTypes(accParent))
+                                                {
+                                                    foreach (var info in type.GetMember(attrName,
+                                                                 BindingFlags.Public | BindingFlags.NonPublic |
+                                                                 BindingFlags.Instance | BindingFlags.Static |
+                                                                 BindingFlags.FlattenHierarchy))
+                                                    {
+                                                        if (info == null) continue;
+                                                        accMemberInfo = info;
+                                                        break;
+                                                    }
+                                                }
 
                                                 accResult = Util.GetValueAtIndex(-1, accMemberInfo, accParent);
                                                 if (accResult.error != "")

--- a/Editor/Core/RichTextDrawer.cs
+++ b/Editor/Core/RichTextDrawer.cs
@@ -318,7 +318,7 @@ namespace SaintsField.Editor.Core
                                         if(!RuntimeUtil.IsNull(accParent))
                                         {
                                             // ReSharper disable once ReplaceSubstringWithRangeIndexer
-                                            string[] subFields = parsedResult.content.Substring("field.".Length).Split('.');
+                                            string[] subFields = parsedResult.content.Substring("field.".Length).Split(SerializedUtils.pathSplitSeparator);
                                             foreach (string attrName in subFields)
                                             {
                                                 MemberInfo accMemberInfo = ReflectUtils.GetSelfAndBaseTypes(accParent)

--- a/Editor/Core/SaintsPropertyDrawer.cs
+++ b/Editor/Core/SaintsPropertyDrawer.cs
@@ -194,7 +194,7 @@ namespace SaintsField.Editor.Core
 
                 foreach (Type eachPropertyDrawer in allSubPropertyDrawers)
                 {
-                    foreach (Type attr in eachPropertyDrawer.GetCustomAttributesFast<CustomPropertyDrawer>(true)
+                    foreach (Type attr in ReflectCache.GetCustomAttributes<CustomPropertyDrawer>(eachPropertyDrawer, true)
                                  .Select(instance => typeof(CustomPropertyDrawer)
                                      .GetField("m_Type", BindingFlags.NonPublic | BindingFlags.Instance)
                                      ?.GetValue(instance))
@@ -219,7 +219,7 @@ namespace SaintsField.Editor.Core
 
                 foreach (Type eachDecoratorDrawer in allSubDecoratorDrawers)
                 {
-                    foreach (Type attr in eachDecoratorDrawer.GetCustomAttributesFast<CustomPropertyDrawer>(true)
+                    foreach (Type attr in ReflectCache.GetCustomAttributes<CustomPropertyDrawer>(eachDecoratorDrawer, true)
                                  .Select(instance => typeof(CustomPropertyDrawer)
                                      .GetField("m_Type", BindingFlags.NonPublic | BindingFlags.Instance)
                                      ?.GetValue(instance))
@@ -250,7 +250,7 @@ namespace SaintsField.Editor.Core
                         {
                             IsSaints = each.IsSubclassOf(typeof(SaintsPropertyDrawer)),
                             DrawerType = each,
-                            UseForChildren = each.GetCustomAttributesFast<CustomPropertyDrawer>(true)
+                            UseForChildren = ReflectCache.GetCustomAttributes<CustomPropertyDrawer>(each, true)
                                 .Any(instance => typeof(CustomPropertyDrawer)
                                     .GetField("m_UseForChildren", BindingFlags.NonPublic | BindingFlags.Instance)
                                     ?.GetValue(instance) is bool useForChildren && useForChildren)
@@ -325,15 +325,19 @@ namespace SaintsField.Editor.Core
         private static (Attribute attributeInstance, Type attributeDrawerType) GetOtherAttributeDrawerType(MemberInfo fieldInfo)
         {
             // ReSharper disable once UseNegatedPatternInIsExpression
-            foreach (Attribute fieldAttribute in fieldInfo.GetCustomAttributesFast().Where(each => !(each is ISaintsAttribute)))
+            foreach (Attribute fieldAttribute in ReflectCache.GetCustomAttributes(fieldInfo))
             {
-                foreach (KeyValuePair<Type,IReadOnlyList<PropertyDrawerInfo>> kv in PropertyAttributeToPropertyDrawers)
+                if (fieldAttribute is ISaintsAttribute)
+                    continue;
+
+                foreach (KeyValuePair<Type, IReadOnlyList<PropertyDrawerInfo>> kv in PropertyAttributeToPropertyDrawers)
                 {
                     Type canDrawType = kv.Key;
                     // Debug.Log($"{fieldAttribute}:{kv.Key}:--");
                     // foreach ((bool isSaints, Type drawerType) in kv.Value.Where(each => !each.isSaints))
-                    foreach (var info in kv.Value.Where(each => !each.IsSaints))
+                    foreach (var info in kv.Value)
                     {
+                        if (info.IsSaints) continue;
                         // if ($"{drawerType}" == "UnityEditor.RangeDrawer")
                         // {
                         //     Debug.Log($"{canDrawType}:{fieldAttribute}={drawerType} -- {canDrawType.IsInstanceOfType(fieldAttribute)}");

--- a/Editor/Core/SaintsPropertyDrawer.cs
+++ b/Editor/Core/SaintsPropertyDrawer.cs
@@ -60,11 +60,16 @@ namespace SaintsField.Editor.Core
         private static bool _sceneViewNotificationListened;
         private static readonly HashSet<string> SceneViewNotifications = new HashSet<string>();
 
-        private struct SaintsWithIndex : IEquatable<SaintsWithIndex>
+        private readonly struct SaintsWithIndex : IEquatable<SaintsWithIndex>
         {
-            public ISaintsAttribute SaintsAttribute;
-            // ReSharper disable once NotAccessedField.Local
-            public int Index;
+            public readonly ISaintsAttribute SaintsAttribute;
+            public readonly int Index;
+
+            public SaintsWithIndex(ISaintsAttribute saintsAttribute, int index)
+            {
+                SaintsAttribute = saintsAttribute;
+                Index = index;
+            }
 
             public bool Equals(SaintsWithIndex other)
             {

--- a/Editor/Core/SaintsPropertyDrawer.cs
+++ b/Editor/Core/SaintsPropertyDrawer.cs
@@ -194,7 +194,7 @@ namespace SaintsField.Editor.Core
 
                 foreach (Type eachPropertyDrawer in allSubPropertyDrawers)
                 {
-                    foreach (Type attr in eachPropertyDrawer.GetCustomAttributes<CustomPropertyDrawer>(true)
+                    foreach (Type attr in eachPropertyDrawer.GetCustomAttributesFast<CustomPropertyDrawer>(true)
                                  .Select(instance => typeof(CustomPropertyDrawer)
                                      .GetField("m_Type", BindingFlags.NonPublic | BindingFlags.Instance)
                                      ?.GetValue(instance))
@@ -219,7 +219,7 @@ namespace SaintsField.Editor.Core
 
                 foreach (Type eachDecoratorDrawer in allSubDecoratorDrawers)
                 {
-                    foreach (Type attr in eachDecoratorDrawer.GetCustomAttributes<CustomPropertyDrawer>(true)
+                    foreach (Type attr in eachDecoratorDrawer.GetCustomAttributesFast<CustomPropertyDrawer>(true)
                                  .Select(instance => typeof(CustomPropertyDrawer)
                                      .GetField("m_Type", BindingFlags.NonPublic | BindingFlags.Instance)
                                      ?.GetValue(instance))
@@ -250,7 +250,7 @@ namespace SaintsField.Editor.Core
                         {
                             IsSaints = each.IsSubclassOf(typeof(SaintsPropertyDrawer)),
                             DrawerType = each,
-                            UseForChildren = each.GetCustomAttributes<CustomPropertyDrawer>(true)
+                            UseForChildren = each.GetCustomAttributesFast<CustomPropertyDrawer>(true)
                                 .Any(instance => typeof(CustomPropertyDrawer)
                                     .GetField("m_UseForChildren", BindingFlags.NonPublic | BindingFlags.Instance)
                                     ?.GetValue(instance) is bool useForChildren && useForChildren)
@@ -325,7 +325,7 @@ namespace SaintsField.Editor.Core
         private static (Attribute attributeInstance, Type attributeDrawerType) GetOtherAttributeDrawerType(MemberInfo fieldInfo)
         {
             // ReSharper disable once UseNegatedPatternInIsExpression
-            foreach (Attribute fieldAttribute in fieldInfo.GetCustomAttributes().Where(each => !(each is ISaintsAttribute)))
+            foreach (Attribute fieldAttribute in fieldInfo.GetCustomAttributesFast().Where(each => !(each is ISaintsAttribute)))
             {
                 foreach (KeyValuePair<Type,IReadOnlyList<PropertyDrawerInfo>> kv in PropertyAttributeToPropertyDrawers)
                 {

--- a/Editor/Core/SaintsPropertyDrawerIMGUI.cs
+++ b/Editor/Core/SaintsPropertyDrawerIMGUI.cs
@@ -164,11 +164,7 @@ namespace SaintsField.Editor.Core
             List<SaintsWithIndex> saintsAttributeWithIndexes = allAttributes
                 .OfType<ISaintsAttribute>()
                 // .Where(each => !(each is VisibilityAttribute))
-                .Select((each, index) => new SaintsWithIndex
-                {
-                    SaintsAttribute = each,
-                    Index = index,
-                })
+                .Select((each, index) => new SaintsWithIndex(each, index))
                 .ToList();
 
             Dictionary<SaintsWithIndex, SaintsPropertyDrawer> usedAttributes = saintsAttributeWithIndexes
@@ -188,11 +184,7 @@ namespace SaintsField.Editor.Core
 
             if (UseCreateFieldIMGUI && fieldFound.iSaintsAttribute is null)
             {
-                SaintsWithIndex thisFake = new SaintsWithIndex
-                {
-                    Index = -1,
-                    SaintsAttribute = null,
-                };
+                SaintsWithIndex thisFake = new SaintsWithIndex(null, -1);
                 saintsAttributeWithIndexes.Insert(0, thisFake);
                 usedAttributes[thisFake] = this;
             }
@@ -431,11 +423,7 @@ namespace SaintsField.Editor.Core
             }
 
             List<SaintsWithIndex> allSaintsAttributes = iSaintsAttributes
-                .Select((each, index) => new SaintsWithIndex
-                {
-                    SaintsAttribute = each,
-                    Index = index,
-                })
+                .Select((each, index) => new SaintsWithIndex(each, index))
                 .ToList();
 
             SaintsWithIndex fieldAttributeWithIndex =
@@ -446,11 +434,7 @@ namespace SaintsField.Editor.Core
 
             if (useCreateFieldIMGUI)
             {
-                fieldAttributeWithIndex = new SaintsWithIndex
-                {
-                    Index = -1,
-                    SaintsAttribute = null,
-                };
+                fieldAttributeWithIndex = new SaintsWithIndex(null, -1);
                 allSaintsAttributes.Insert(0, fieldAttributeWithIndex);
             }
 

--- a/Editor/Core/SaintsPropertyDrawerIMGUI.cs
+++ b/Editor/Core/SaintsPropertyDrawerIMGUI.cs
@@ -1264,7 +1264,7 @@ namespace SaintsField.Editor.Core
                 // this code is used to prevent the decorator to be drawn everytime a fallback happens
                 // the marco is not added by default
 #if UNITY_2022_1_OR_NEWER && SAINTSFIELD_IMGUI_DUPLICATE_DECORATOR_FIX
-                Type dec = fieldInfo.GetCustomAttributes<PropertyAttribute>(true)
+                Type dec = fieldInfo.GetCustomAttributesFast<PropertyAttribute>(true)
                     .Select(propertyAttribute =>
                     {
                         // Debug.Log(propertyAttribute.GetType());

--- a/Editor/Drawers/ButtonAddOnClickAttributeDrawer.cs
+++ b/Editor/Drawers/ButtonAddOnClickAttributeDrawer.cs
@@ -92,8 +92,7 @@ namespace SaintsField.Editor.Drawers
                 return "Can not find parent target";
             }
 
-            // ReSharper disable once LoopCanBeConvertedToQuery
-            foreach (int eventIndex in Enumerable.Range(0, uiButton.onClick.GetPersistentEventCount()))
+            for (int eventIndex = 0; eventIndex < uiButton.onClick.GetPersistentEventCount(); eventIndex++)
             {
                 Object persistentTarget = uiButton.onClick.GetPersistentTarget(eventIndex);
                 string persistentMethodName = uiButton.onClick.GetPersistentMethodName(eventIndex);

--- a/Editor/Drawers/CustomPicker/FieldTypeDrawer/FieldTypeAttributeDrawer.cs
+++ b/Editor/Drawers/CustomPicker/FieldTypeDrawer/FieldTypeAttributeDrawer.cs
@@ -38,11 +38,11 @@ namespace SaintsField.Editor.Drawers.CustomPicker.FieldTypeDrawer
 
             protected override bool AllowScene =>
                 // Debug.Log(_editorPick);
-                _editorPick.HasFlag(EPick.Scene);
+                _editorPick.HasFlagFast(EPick.Scene);
 
             protected override bool AllowAssets =>
                 // Debug.Log(_editorPick);
-                _editorPick.HasFlag(EPick.Assets);
+                _editorPick.HasFlagFast(EPick.Assets);
 
             private string _error = "";
             protected override string Error => _error;

--- a/Editor/Drawers/CustomPicker/FieldTypeDrawer/FieldTypeAttributeDrawerIMGUI.cs
+++ b/Editor/Drawers/CustomPicker/FieldTypeDrawer/FieldTypeAttributeDrawerIMGUI.cs
@@ -51,7 +51,7 @@ namespace SaintsField.Editor.Drawers.CustomPicker.FieldTypeDrawer
                     : position;
 
                 Object fieldResult =
-                    EditorGUI.ObjectField(fieldRect, label, requiredValue, requiredComp, editorPick.HasFlag(EPick.Scene));
+                    EditorGUI.ObjectField(fieldRect, label, requiredValue, requiredComp, editorPick.HasFlagFast(EPick.Scene));
                 // ReSharper disable once InvertIf
                 if (changed.changed)
                 {

--- a/Editor/Drawers/CustomPicker/RequireTypeDrawer/RequireTypeAttributeDrawer.cs
+++ b/Editor/Drawers/CustomPicker/RequireTypeDrawer/RequireTypeAttributeDrawer.cs
@@ -42,11 +42,11 @@ namespace SaintsField.Editor.Drawers.CustomPicker.RequireTypeDrawer
 
             protected override bool AllowScene =>
                 // Debug.Log(_editorPick);
-                _editorPick.HasFlag(EPick.Scene);
+                _editorPick.HasFlagFast(EPick.Scene);
 
             protected override bool AllowAssets =>
                 // Debug.Log(_editorPick);
-                _editorPick.HasFlag(EPick.Assets);
+                _editorPick.HasFlagFast(EPick.Assets);
 
             private string _error = "";
             protected override string Error => _error;

--- a/Editor/Drawers/DropdownDrawer/DropdownAttributeDrawer.cs
+++ b/Editor/Drawers/DropdownDrawer/DropdownAttributeDrawer.cs
@@ -149,7 +149,7 @@ namespace SaintsField.Editor.Drawers.DropdownDrawer
 
             IReadOnlyList<(string, object, bool, bool)> dropdownActualList = dropdownListValueUnique.ToArray();
 
-            foreach (int dropdownIndex in Enumerable.Range(0, dropdownActualList.Count))
+            for (var dropdownIndex = 0; dropdownIndex < dropdownActualList.Count; dropdownIndex++)
             {
                 (string _, object itemValue, bool _, bool isSeparator) = dropdownActualList[dropdownIndex];
                 if (isSeparator)

--- a/Editor/Drawers/DropdownDrawer/DropdownAttributeDrawerUIToolkit.cs
+++ b/Editor/Drawers/DropdownDrawer/DropdownAttributeDrawerUIToolkit.cs
@@ -141,7 +141,7 @@ namespace SaintsField.Editor.Drawers.DropdownDrawer
                 // FIXED: can not get correct index
                 int selectedIndex = metaInfo.SelectedIndex;
                 // Debug.Log($"metaInfo.SelectedIndex={metaInfo.SelectedIndex}");
-                foreach (int index in Enumerable.Range(0, metaInfo.DropdownListValue.Count))
+                for (var index = 0; index < metaInfo.DropdownListValue.Count; index++)
                 {
                     // int curIndex = index;
                     (string curName, object curItem, bool disabled, bool curIsSeparator) =

--- a/Editor/Drawers/HandleDrawers/HandleColorScoop.cs
+++ b/Editor/Drawers/HandleDrawers/HandleColorScoop.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 namespace SaintsField.Editor.Drawers.HandleDrawers
 {
-    public class HandleColorScoop: IDisposable
+    public readonly struct HandleColorScoop: IDisposable
     {
         private readonly Color _oldColor;
 

--- a/Editor/Drawers/InputAxisAttributeDrawer.cs
+++ b/Editor/Drawers/InputAxisAttributeDrawer.cs
@@ -142,7 +142,7 @@ namespace SaintsField.Editor.Drawers
             int selectedIndex = IndexOf(axisNames, property.stringValue);
 
             // Debug.Log($"metaInfo.SelectedIndex={metaInfo.SelectedIndex}");
-            foreach (int index in Enumerable.Range(0, axisNames.Count))
+            for (var index = 0; index < axisNames.Count; index++)
             {
                 int curIndex = index;
 

--- a/Editor/Drawers/OnValueChangedAttributeDrawer.cs
+++ b/Editor/Drawers/OnValueChangedAttributeDrawer.cs
@@ -69,13 +69,10 @@ namespace SaintsField.Editor.Drawers
 
             // object parent = SerializedUtils.GetFieldInfoAndDirectParent(property).parent;
 
-            IReadOnlyList<Type> types = ReflectUtils.GetSelfAndBaseTypes(parent);
-            // types.Reverse();
-
             const BindingFlags bindAttr = BindingFlags.Instance | BindingFlags.Static | BindingFlags.NonPublic |
                                           BindingFlags.Public | BindingFlags.DeclaredOnly | BindingFlags.FlattenHierarchy;
 
-            foreach (Type type in types)
+            foreach (Type type in ReflectUtils.GetSelfAndBaseTypes(parent))
             {
                 MethodInfo methodInfo = type.GetMethod(callback, bindAttr);
                 if (methodInfo == null)

--- a/Editor/Drawers/ProgressBarDrawer/ProgressBarAttributeDrawer.cs
+++ b/Editor/Drawers/ProgressBarDrawer/ProgressBarAttributeDrawer.cs
@@ -170,13 +170,11 @@ namespace SaintsField.Editor.Drawers.ProgressBarDrawer
                 return ("", $"{formatValue} / {maxValue}");
             }
 
-            IReadOnlyList<Type> types = ReflectUtils.GetSelfAndBaseTypes(parent);
-
             const BindingFlags bindAttr = BindingFlags.Instance | BindingFlags.Static | BindingFlags.NonPublic |
                                           BindingFlags.Public | BindingFlags.DeclaredOnly | BindingFlags.FlattenHierarchy;
 
             // ReSharper disable once ForeachCanBePartlyConvertedToQueryUsingAnotherGetEnumerator
-            foreach (Type type in types)
+            foreach (Type type in ReflectUtils.GetSelfAndBaseTypes(parent))
             {
                 MethodInfo methodInfo = type.GetMethod(titleCallback, bindAttr);
                 if (methodInfo == null)

--- a/Editor/Drawers/SaintsDictionary/SaintsDictionaryDrawerIMGUI.cs
+++ b/Editor/Drawers/SaintsDictionary/SaintsDictionaryDrawerIMGUI.cs
@@ -303,19 +303,25 @@ namespace SaintsField.Editor.Drawers.SaintsDictionary
                 SerializedProperty keysProp = property.FindPropertyRelative(propKeysName) ?? SerializedUtils.FindPropertyByAutoPropertyName(property, propKeysName);
                 SerializedProperty valuesProp = property.FindPropertyRelative(propValuesName) ?? SerializedUtils.FindPropertyByAutoPropertyName(property, propValuesName);
 
-                FieldInfo keysField =
-                    ReflectUtils.GetSelfAndBaseTypesFromType(rawType)
-                        .Select(each => each.GetField(propKeysName,
-                            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance |
-                            BindingFlags.FlattenHierarchy))
-                        .FirstOrDefault(each => each != null);
-                    // rawType.GetField(propKeysName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance  | BindingFlags.FlattenHierarchy);
+                FieldInfo keysField = null;
+                foreach (var each in ReflectUtils.GetSelfAndBaseTypesFromType(rawType))
+                {
+                    var field = each.GetField(propKeysName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.FlattenHierarchy);
+                    if (field == null) continue;
+                    keysField = field;
+                    break;
+                }
+                // rawType.GetField(propKeysName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance  | BindingFlags.FlattenHierarchy);
                 Debug.Assert(keysField != null, $"Failed to get keys field {propKeysName} from {property.propertyPath}");
-                FieldInfo valuesField =
-                    ReflectUtils.GetSelfAndBaseTypesFromType(rawType)
-                        .Select(each => each.GetField(propValuesName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.FlattenHierarchy))
-                        .FirstOrDefault(each => each != null);
-                    // rawType.GetField(propValuesName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance  | BindingFlags.FlattenHierarchy);
+                FieldInfo valuesField = null;
+                foreach (var each in ReflectUtils.GetSelfAndBaseTypesFromType(rawType))
+                {
+                    var field = each.GetField(propValuesName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.FlattenHierarchy);
+                    if (field == null) continue;
+                    valuesField = field;
+                    break;
+                }
+                // rawType.GetField(propValuesName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance  | BindingFlags.FlattenHierarchy);
                 Debug.Assert(valuesField != null, $"Failed to get values field {propValuesName} from {property.propertyPath}");
 
                 float useWidth = Mathf.Max(width / 2 - 25, 25);

--- a/Editor/Drawers/SaintsDictionary/SaintsDictionaryDrawerUIToolkit.cs
+++ b/Editor/Drawers/SaintsDictionary/SaintsDictionaryDrawerUIToolkit.cs
@@ -299,17 +299,23 @@ namespace SaintsField.Editor.Drawers.SaintsDictionary
             SerializedProperty keysProp = property.FindPropertyRelative(propKeysName) ?? SerializedUtils.FindPropertyByAutoPropertyName(property, propKeysName);
             SerializedProperty valuesProp = property.FindPropertyRelative(propValuesName) ?? SerializedUtils.FindPropertyByAutoPropertyName(property, propValuesName);
 
-            FieldInfo keysField =
-                ReflectUtils.GetSelfAndBaseTypesFromType(rawType)
-                    .Select(each => each.GetField(propKeysName,
-                        BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance |
-                        BindingFlags.FlattenHierarchy))
-                    .FirstOrDefault(each => each != null);
+            FieldInfo keysField = null;
+            foreach (var each in ReflectUtils.GetSelfAndBaseTypesFromType(rawType))
+            {
+                var field = each.GetField(propKeysName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.FlattenHierarchy);
+                if (field == null) continue;
+                keysField = field;
+                break;
+            }
             Debug.Assert(keysField != null, $"Failed to get keys field from {property.propertyPath}");
-            FieldInfo valuesField =
-                ReflectUtils.GetSelfAndBaseTypesFromType(rawType)
-                    .Select(each => each.GetField(propValuesName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.FlattenHierarchy))
-                    .FirstOrDefault(each => each != null);
+            FieldInfo valuesField = null;
+            foreach (var each in ReflectUtils.GetSelfAndBaseTypesFromType(rawType))
+            {
+                var each1 = each.GetField(propValuesName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.FlattenHierarchy);
+                if (each1 == null) continue;
+                valuesField = each1;
+                break;
+            }
             Debug.Assert(valuesField != null, $"Failed to get values field from {property.propertyPath}");
 
             IntegerField totalCountFieldTop = container.Q<IntegerField>(name: NameTotalCount(property));

--- a/Editor/Drawers/SceneDrawer/SceneAttributeDrawerUIToolkit.cs
+++ b/Editor/Drawers/SceneDrawer/SceneAttributeDrawerUIToolkit.cs
@@ -69,7 +69,7 @@ namespace SaintsField.Editor.Drawers.SceneDrawer
 
             (int selectedIndex, string _) = GetSelected(property, (SceneAttribute)saintsAttribute);
 
-            foreach (int index in Enumerable.Range(0, scenes.Length))
+            for (var index = 0; index < scenes.Length; index++)
             {
                 int curIndex = index;
                 string curItem = scenes[index];

--- a/Editor/Drawers/ShaderDrawers/ShaderParamDrawer/ShaderParamAttributeDrawer.cs
+++ b/Editor/Drawers/ShaderDrawers/ShaderParamDrawer/ShaderParamAttributeDrawer.cs
@@ -63,7 +63,7 @@ namespace SaintsField.Editor.Drawers.ShaderDrawers.ShaderParamDrawer
 
         private static IEnumerable<ShaderInfo> GetShaderInfo(Shader shader, ShaderPropertyType? filterPropertyType)
         {
-            foreach (int index in Enumerable.Range(0, shader.GetPropertyCount()))
+            for (int index = 0; index < shader.GetPropertyCount(); index++)
             {
                 string propertyName = shader.GetPropertyName(index);
                 string propertyDescription = shader.GetPropertyDescription(index);

--- a/Editor/Drawers/SortingLayerAttributeDrawer.cs
+++ b/Editor/Drawers/SortingLayerAttributeDrawer.cs
@@ -175,7 +175,7 @@ namespace SaintsField.Editor.Drawers
 
             UIToolkitUtils.DropdownButtonField buttonLabel = container.Q<UIToolkitUtils.DropdownButtonField>(NameButtonField(property));
 
-            foreach (int index in Enumerable.Range(0, layers.Length))
+            for (var index = 0; index < layers.Length; index++)
             {
                 int curIndex = index;
                 string curItem = layers[index];

--- a/Editor/Drawers/Spine/SpineAttachmentPickerDrawer/SpineAttachmentPickerAttributeDrawer.cs
+++ b/Editor/Drawers/Spine/SpineAttachmentPickerDrawer/SpineAttachmentPickerAttributeDrawer.cs
@@ -182,8 +182,7 @@ namespace SaintsField.Editor.Drawers.Spine.SpineAttachmentPickerDrawer
                     prefix = skinPrefix;
                 }
 
-                // for (int slotIndex = 0; slotIndex < skeletonData.Slots.Count; slotIndex++) {
-                foreach(int slotIndex in Enumerable.Range(0, skeletonData.Slots.Count)) {
+                for (int slotIndex = 0; slotIndex < skeletonData.Slots.Count; slotIndex++) {
                     if (slotMatch.Length > 0 && !skeletonData.Slots.Items[slotIndex].Name.Equals(slotMatch, StringComparison.OrdinalIgnoreCase))
                     {
                         continue;

--- a/Editor/Drawers/TableDrawer/TableAttributeDrawerUIToolkit.cs
+++ b/Editor/Drawers/TableDrawer/TableAttributeDrawerUIToolkit.cs
@@ -231,7 +231,7 @@ namespace SaintsField.Editor.Drawers.TableDrawer
                         VisualElement itemContainer = new VisualElement();
                         // PropertyField propField = new PropertyField();
                         // itemContainer.Add(propField);
-                        foreach (int _ in Enumerable.Range(0, properties.Count))
+                        for (var i = 0; i < properties.Count; i++)
                         {
                             itemContainer.Add(new PropertyField());
                         }
@@ -335,10 +335,9 @@ namespace SaintsField.Editor.Drawers.TableDrawer
                         // PropertyField propField = new PropertyField();
                         // itemContainer.Add(propField);
                         // ReSharper disable once ForeachCanBePartlyConvertedToQueryUsingAnotherGetEnumerator
-                        foreach (int _ in Enumerable.Range(0, properties.Count))
+                        for (var i = 0; i < properties.Count; i++)
                         {
-                            PropertyField propField = new PropertyField();
-                            itemContainer.Add(propField);
+                            itemContainer.Add(new PropertyField());
                         }
                         return itemContainer;
                     };

--- a/Editor/Drawers/XPathDrawers/GetByXPathDrawer/GetByXPathAttributeDrawer.cs
+++ b/Editor/Drawers/XPathDrawers/GetByXPathDrawer/GetByXPathAttributeDrawer.cs
@@ -245,7 +245,7 @@ namespace SaintsField.Editor.Drawers.XPathDrawers.GetByXPathDrawer
                             .arraySize) // reducing the size, let's check if we need to shift the array first (to erase null values)
                     {
                         int accValueIndex = 0;
-                        foreach (int arrayIndex in Enumerable.Range(0, target.ArrayProperty.arraySize))
+                        for (int arrayIndex = 0; arrayIndex < target.ArrayProperty.arraySize; arrayIndex++)
                         {
                             SerializedProperty element = target.ArrayProperty.GetArrayElementAtIndex(arrayIndex);
                             if (element.propertyType != SerializedPropertyType.ObjectReference)

--- a/Editor/Drawers/XPathDrawers/GetByXPathDrawer/GetByXPathAttributeDrawerPickerWindow.cs
+++ b/Editor/Drawers/XPathDrawers/GetByXPathDrawer/GetByXPathAttributeDrawerPickerWindow.cs
@@ -36,11 +36,11 @@ namespace SaintsField.Editor.Drawers.XPathDrawers.GetByXPathDrawer
 
             protected override bool AllowScene =>
                 // Debug.Log(_editorPick);
-                _editorPick.HasFlag(EPick.Scene);
+                _editorPick.HasFlagFast(EPick.Scene);
 
             protected override bool AllowAssets =>
                 // Debug.Log(_editorPick);
-                _editorPick.HasFlag(EPick.Assets);
+                _editorPick.HasFlagFast(EPick.Assets);
 
             protected override IEnumerable<ItemInfo> FetchAllAssets()
             {

--- a/Editor/Playa/Renderer/BaseRenderer/AbsRenderer.cs
+++ b/Editor/Playa/Renderer/BaseRenderer/AbsRenderer.cs
@@ -55,7 +55,7 @@ namespace SaintsField.Editor.Playa.Renderer.BaseRenderer
 
         protected PreCheckResult GetPreCheckResult(SaintsFieldWithInfo fieldWithInfo, bool isImGui)
         {
-            List<ToggleCheckInfo> preCheckInternalInfos = new List<ToggleCheckInfo>();
+            List<ToggleCheckInfo> preCheckInternalInfos = new List<ToggleCheckInfo>(fieldWithInfo.PlayaAttributes.Count);
             (int, int) arraySize = (-1, -1);
             foreach (IPlayaAttribute playaAttribute in fieldWithInfo.PlayaAttributes)
             {
@@ -63,27 +63,27 @@ namespace SaintsField.Editor.Playa.Renderer.BaseRenderer
                 {
                     case IVisibilityAttribute visibilityAttribute:
                         preCheckInternalInfos.Add(new ToggleCheckInfo
-                        {
-                            Type = visibilityAttribute.IsShow? ToggleType.Show: ToggleType.Hide,
-                            ConditionInfos = visibilityAttribute.ConditionInfos,
-                            Target = fieldWithInfo.Target,
-                        });
+                        (
+                            visibilityAttribute.IsShow? ToggleType.Show: ToggleType.Hide,
+                            visibilityAttribute.ConditionInfos,
+                            fieldWithInfo.Target
+                        ));
                         break;
                     case PlayaEnableIfAttribute enableIfAttribute:
                         preCheckInternalInfos.Add(new ToggleCheckInfo
-                        {
-                            Type = ToggleType.Enable,
-                            ConditionInfos = enableIfAttribute.ConditionInfos,
-                            Target = fieldWithInfo.Target,
-                        });
+                        (
+                            ToggleType.Enable,
+                            enableIfAttribute.ConditionInfos,
+                            fieldWithInfo.Target
+                        ));
                         break;
                     case PlayaDisableIfAttribute disableIfAttribute:
                         preCheckInternalInfos.Add(new ToggleCheckInfo
-                        {
-                            Type = ToggleType.Disable,
-                            ConditionInfos = disableIfAttribute.ConditionInfos,
-                            Target = fieldWithInfo.Target,
-                        });
+                        (
+                            ToggleType.Disable,
+                            disableIfAttribute.ConditionInfos,
+                            fieldWithInfo.Target
+                        ));
                         break;
                     case IPlayaArraySizeAttribute arraySizeAttribute:
                         if(fieldWithInfo.SerializedProperty != null)
@@ -98,9 +98,9 @@ namespace SaintsField.Editor.Playa.Renderer.BaseRenderer
                 }
             }
 
-            foreach (ToggleCheckInfo preCheckInternalInfo in preCheckInternalInfos)
+            for (var i = 0; i < preCheckInternalInfos.Count; i++)
             {
-                SaintsEditorUtils.FillResult(preCheckInternalInfo);
+                preCheckInternalInfos[i] = SaintsEditorUtils.FillResult(preCheckInternalInfos[i]);
             }
 
             (bool showIfResult, bool disableIfResult) = SaintsEditorUtils.GetToggleResult(preCheckInternalInfos);

--- a/Editor/Playa/Renderer/BaseRenderer/AbsRenderer.cs
+++ b/Editor/Playa/Renderer/BaseRenderer/AbsRenderer.cs
@@ -191,9 +191,8 @@ namespace SaintsField.Editor.Playa.Renderer.BaseRenderer
         {
             object target = fieldWithInfo.Target;
 
-            IReadOnlyList<Type> types = ReflectUtils.GetSelfAndBaseTypes(target);
             // types.Reverse();
-            foreach (Type eachType in types)
+            foreach (Type eachType in ReflectUtils.GetSelfAndBaseTypes(target))
             {
                 (ReflectUtils.GetPropType getPropType, object fieldOrMethodInfo) =
                     ReflectUtils.GetProp(eachType, by);

--- a/Editor/Playa/Renderer/BaseRenderer/SerializedFieldBaseRenderer.cs
+++ b/Editor/Playa/Renderer/BaseRenderer/SerializedFieldBaseRenderer.cs
@@ -23,13 +23,10 @@ namespace SaintsField.Editor.Playa.Renderer.BaseRenderer
 
         private static void InvokeCallback(string callback, object newValue, object parent)
         {
-            IReadOnlyList<Type> types = ReflectUtils.GetSelfAndBaseTypes(parent);
-            // types.Reverse();
-
             const BindingFlags bindAttr = BindingFlags.Instance | BindingFlags.Static | BindingFlags.NonPublic |
                                           BindingFlags.Public | BindingFlags.DeclaredOnly | BindingFlags.FlattenHierarchy;
 
-            foreach (Type type in types)
+            foreach (Type type in ReflectUtils.GetSelfAndBaseTypes(parent))
             {
                 MethodInfo methodInfo = type.GetMethod(callback, bindAttr);
                 if (methodInfo == null)

--- a/Editor/Playa/Renderer/MethodRenderer.cs
+++ b/Editor/Playa/Renderer/MethodRenderer.cs
@@ -65,7 +65,7 @@ namespace SaintsField.Editor.Playa.Renderer
                 List<string> attrNames = new List<string>();
                 if (eventTarget.Contains("."))
                 {
-                    attrNames.AddRange(eventTarget.Split('.'));
+                    attrNames.AddRange(eventTarget.Split(SerializedUtils.pathSplitSeparator));
                 }
                 else
                 {

--- a/Editor/Playa/Renderer/MethodRenderer.cs
+++ b/Editor/Playa/Renderer/MethodRenderer.cs
@@ -127,8 +127,7 @@ namespace SaintsField.Editor.Playa.Renderer
                 }
             }
 
-            // ReSharper disable once LoopCanBeConvertedToQuery
-            foreach (int eventIndex in Enumerable.Range(0, unityEventBase.GetPersistentEventCount()))
+            for (int eventIndex = 0; eventIndex < unityEventBase.GetPersistentEventCount(); eventIndex++)
             {
                 UnityEngine.Object persistentTarget = unityEventBase.GetPersistentTarget(eventIndex);
                 string persistentMethodName = unityEventBase.GetPersistentMethodName(eventIndex);

--- a/Editor/Playa/RendererGroup/SaintsRendererGroup.cs
+++ b/Editor/Playa/RendererGroup/SaintsRendererGroup.cs
@@ -39,7 +39,7 @@ namespace SaintsField.Editor.Playa.RendererGroup
 
         private readonly object _containerObject;
 
-        private readonly IReadOnlyList<ToggleCheckInfo> _toggleCheckInfos;
+        private readonly List<ToggleCheckInfo> _toggleCheckInfos;
 
         public SaintsRendererGroup(string groupPath, Config config, object containerObject)
         {
@@ -49,7 +49,7 @@ namespace SaintsField.Editor.Playa.RendererGroup
             _foldout = !config.ELayout.HasFlag(ELayout.Collapse);
             _containerObject = containerObject;
 
-            List<ToggleCheckInfo> toggleCheckInfos = new List<ToggleCheckInfo>();
+            List<ToggleCheckInfo> toggleCheckInfos = new List<ToggleCheckInfo>(_config.Toggles.Count);
 
             foreach (ISaintsLayoutToggle configToggle in _config.Toggles)
             {
@@ -59,36 +59,36 @@ namespace SaintsField.Editor.Playa.RendererGroup
                         // layoutEnableIf.Add(layoutEnableIfAttribute);
                         // Debug.Log(layoutEnableIfAttribute);
                         toggleCheckInfos.Add(new ToggleCheckInfo
-                        {
-                            Type = ToggleType.Enable,
-                            ConditionInfos = layoutEnableIfAttribute.ConditionInfos,
-                            Target = _containerObject,
-                        });
+                        (
+                            ToggleType.Enable,
+                            layoutEnableIfAttribute.ConditionInfos,
+                            _containerObject
+                        ));
                         break;
                     case LayoutReadOnlyAttribute layoutReadOnlyAttribute:
                         toggleCheckInfos.Add(new ToggleCheckInfo
-                        {
-                            Type = ToggleType.Disable,
-                            ConditionInfos = layoutReadOnlyAttribute.ConditionInfos,
-                            Target = _containerObject,
-                        });
+                        (
+                            ToggleType.Disable,
+                            layoutReadOnlyAttribute.ConditionInfos,
+                            _containerObject
+                        ));
                         break;
 
                     case LayoutHideIfAttribute layoutHideIfAttribute:
                         toggleCheckInfos.Add(new ToggleCheckInfo
-                        {
-                            Type = ToggleType.Hide,
-                            ConditionInfos = layoutHideIfAttribute.ConditionInfos,
-                            Target = _containerObject,
-                        });
+                        (
+                            ToggleType.Hide,
+                            layoutHideIfAttribute.ConditionInfos,
+                            _containerObject
+                        ));
                         break;
                     case LayoutShowIfAttribute layoutShowIfAttribute:
                         toggleCheckInfos.Add(new ToggleCheckInfo
-                        {
-                            Type = ToggleType.Show,
-                            ConditionInfos = layoutShowIfAttribute.ConditionInfos,
-                            Target = _containerObject,
-                        });
+                        (
+                            ToggleType.Show,
+                            layoutShowIfAttribute.ConditionInfos,
+                            _containerObject
+                        ));
                         break;
 
                     default:

--- a/Editor/Playa/RendererGroup/SaintsRendererGroup.cs
+++ b/Editor/Playa/RendererGroup/SaintsRendererGroup.cs
@@ -46,7 +46,7 @@ namespace SaintsField.Editor.Playa.RendererGroup
             _groupPath = groupPath;
             _config = config;
             _eLayout = config.ELayout;
-            _foldout = !config.ELayout.HasFlag(ELayout.Collapse);
+            _foldout = !config.ELayout.HasFlagFast(ELayout.Collapse);
             _containerObject = containerObject;
 
             List<ToggleCheckInfo> toggleCheckInfos = new List<ToggleCheckInfo>(_config.Toggles.Count);
@@ -133,11 +133,11 @@ namespace SaintsField.Editor.Playa.RendererGroup
 
         public override string ToString() => $"<Group path={_groupPath} layout={_eLayout}/>";
 
-        private static bool IsFancyBox(ELayout eLayout) => eLayout.HasFlag(ELayout.Background) || eLayout.HasFlag(ELayout.Tab);
+        private static bool IsFancyBox(ELayout eLayout) => eLayout.HasFlagFast(ELayout.Background) || eLayout.HasFlagFast(ELayout.Tab);
 
         private static bool NeedIndentCheck(ELayout eLayout) => IsFancyBox(eLayout) ||
-                                                                eLayout.HasFlag(ELayout.Foldout) ||
-                                                                eLayout.HasFlag(ELayout.Collapse);
+                                                                eLayout.HasFlagFast(ELayout.Foldout) ||
+                                                                eLayout.HasFlagFast(ELayout.Collapse);
 
     }
 }

--- a/Editor/Playa/RendererGroup/SaintsRendererGroupIMGUI.cs
+++ b/Editor/Playa/RendererGroup/SaintsRendererGroupIMGUI.cs
@@ -84,7 +84,7 @@ namespace SaintsField.Editor.Playa.RendererGroup
 
         private IEnumerable<ISaintsRenderer> GetRenderer()
         {
-            return _eLayout.HasFlag(ELayout.Tab)
+            return _eLayout.HasFlagFast(ELayout.Tab)
                 ? _groupIdToRenderer[_orderedKeys[_curSelected]]
                 : _renderers.Select(each => each.renderer);
         }
@@ -94,15 +94,15 @@ namespace SaintsField.Editor.Playa.RendererGroup
         {
             float titleHeight = 0f;
 
-            bool hasFoldout = _eLayout.HasFlag(ELayout.Foldout);
-            bool hasTitle = _eLayout.HasFlag(ELayout.Title);
-            bool hasTab = _eLayout.HasFlag(ELayout.Tab);
+            bool hasFoldout = _eLayout.HasFlagFast(ELayout.Foldout);
+            bool hasTitle = _eLayout.HasFlagFast(ELayout.Title);
+            bool hasTab = _eLayout.HasFlagFast(ELayout.Tab);
 
             if (!hasFoldout && hasTitle)  // in this case, draw title above, alone
             {
                 titleHeight += EditorGUIUtility.singleLineHeight;
                 // EditorGUILayout.LabelField(_groupPath.Split('/').Last(), _titleLabelStyle);
-                if(_eLayout.HasFlag(ELayout.TitleOut))
+                if(_eLayout.HasFlagFast(ELayout.TitleOut))
                 {
                     titleHeight += 1;
                     // Rect lineSep = EditorGUILayout.GetControlRect(false, 1);
@@ -119,7 +119,7 @@ namespace SaintsField.Editor.Playa.RendererGroup
                 // _foldout = EditorGUILayout.Foldout(_foldout, _groupPath.Split('/').Last(), true, new GUIStyle(EditorStyles.foldout){
                 //     fontStyle = FontStyle.Bold,
                 // });
-                if(_eLayout.HasFlag(ELayout.TitleOut) && _foldout)
+                if(_eLayout.HasFlagFast(ELayout.TitleOut) && _foldout)
                 {
                     titleHeight += 1f;
                     // Rect lineSep = EditorGUILayout.GetControlRect(false, 1);
@@ -164,7 +164,7 @@ namespace SaintsField.Editor.Playa.RendererGroup
             float contentHeight = 0f;
             if(_foldout)
             {
-                if (_eLayout.HasFlag(ELayout.Horizontal))
+                if (_eLayout.HasFlagFast(ELayout.Horizontal))
                 {
                     contentHeight += Mathf.Max(GetRenderer().Select(each => each.GetHeightIMGUI(width)).ToArray());
                 }
@@ -194,7 +194,7 @@ namespace SaintsField.Editor.Playa.RendererGroup
                 height = position.height - marginTop - marginBottom - 4,
             };
 
-            // Debug.Assert(!_eLayout.HasFlag(ELayout.Horizontal), $"Horizontal is not supported for IMGUI in SaintsEditorAttribute mode");
+            // Debug.Assert(!_eLayout.HasFlagFast(ELayout.Horizontal), $"Horizontal is not supported for IMGUI in SaintsEditorAttribute mode");
 
             // ReSharper disable once ConvertIfStatementToNullCoalescingAssignment
             if(_foldoutSmallStyle == null)
@@ -215,15 +215,15 @@ namespace SaintsField.Editor.Playa.RendererGroup
                 };
             }
 
-            if (_eLayout.HasFlag(ELayout.Background) || _eLayout.HasFlag(ELayout.Tab))
+            if (_eLayout.HasFlagFast(ELayout.Background) || _eLayout.HasFlagFast(ELayout.Tab))
             {
                 GUI.Box(marginedRect, GUIContent.none, EditorStyles.helpBox);
             }
 
-            // GUIStyle fullBoxStyle = _eLayout.HasFlag(ELayout.Background)
+            // GUIStyle fullBoxStyle = _eLayout.HasFlagFast(ELayout.Background)
             //     ? GUI.skin.box
             //     : GUIStyle.none;
-            // IDisposable disposable = _eLayout.HasFlag(ELayout.Horizontal)
+            // IDisposable disposable = _eLayout.HasFlagFast(ELayout.Horizontal)
             //     // ReSharper disable once RedundantCast
             //     ? (IDisposable)new EditorGUILayout.HorizontalScope(fullBoxStyle)
             //     : new EditorGUILayout.VerticalScope(fullBoxStyle);
@@ -237,9 +237,9 @@ namespace SaintsField.Editor.Playa.RendererGroup
 
                 // using (new EditorGUILayout.VerticalScope())
                 {
-                    bool hasFoldout = _eLayout.HasFlag(ELayout.Foldout) || _eLayout.HasFlag(ELayout.Collapse);
-                    bool hasTitle = _eLayout.HasFlag(ELayout.Title);
-                    bool hasTab = _eLayout.HasFlag(ELayout.Tab);
+                    bool hasFoldout = _eLayout.HasFlagFast(ELayout.Foldout) || _eLayout.HasFlagFast(ELayout.Collapse);
+                    bool hasTitle = _eLayout.HasFlagFast(ELayout.Title);
+                    bool hasTab = _eLayout.HasFlagFast(ELayout.Tab);
 
                     Rect titleRect = new Rect(marginedRect)
                     {
@@ -269,7 +269,7 @@ namespace SaintsField.Editor.Playa.RendererGroup
                         titleRect.y += titleRect.height;
                         titleUsedHeight += titleRect.height;
 
-                        if(_eLayout.HasFlag(ELayout.TitleOut))
+                        if(_eLayout.HasFlagFast(ELayout.TitleOut))
                         {
                             titleRect.height = 1;
                             EditorGUI.DrawRect(titleRect, EColor.EditorSeparator.GetColor());
@@ -289,7 +289,7 @@ namespace SaintsField.Editor.Playa.RendererGroup
                             || hasTitle
                             || !hasTab))
                     {
-                        bool fancy = _eLayout.HasFlag(ELayout.TitleOut) && _eLayout.HasFlag(ELayout.Background);
+                        bool fancy = _eLayout.HasFlagFast(ELayout.TitleOut) && _eLayout.HasFlagFast(ELayout.Background);
                         if (fancy) // title clickable foldout
                         {
                             titleRect.height = EditorGUIUtility.singleLineHeight;
@@ -322,7 +322,7 @@ namespace SaintsField.Editor.Playa.RendererGroup
                             titleRect.y += titleRect.height;
                             titleUsedHeight += titleRect.height;
 
-                            if (_eLayout.HasFlag(ELayout.TitleOut) && _foldout)
+                            if (_eLayout.HasFlagFast(ELayout.TitleOut) && _foldout)
                             {
                                 titleRect.height = 1;
                                 EditorGUI.DrawRect(titleRect, EColor.EditorSeparator.GetColor());
@@ -420,7 +420,7 @@ namespace SaintsField.Editor.Playa.RendererGroup
                     //     y = marginedRect.y + titleUsedHeight,
                     //     height = marginedRect.height - titleUsedHeight,
                     // };
-                    if (_eLayout.HasFlag(ELayout.Horizontal))
+                    if (_eLayout.HasFlagFast(ELayout.Horizontal))
                     {
                         ISaintsRenderer[] renderers = GetRenderer().ToArray();
                         float splitWidth = bodyRect.width / renderers.Length;

--- a/Editor/Playa/RendererGroup/SaintsRendererGroupUIToolkit.cs
+++ b/Editor/Playa/RendererGroup/SaintsRendererGroupUIToolkit.cs
@@ -474,7 +474,7 @@ namespace SaintsField.Editor.Playa.RendererGroup
             return root;
         }
 
-        private static void LoopCheckTogglesUIToolkit(IReadOnlyList<ToggleCheckInfo> toggleCheckInfos, VisualElement root, VisualElement body, object target)
+        private static void LoopCheckTogglesUIToolkit(List<ToggleCheckInfo> toggleCheckInfos, VisualElement root, VisualElement body, object target)
         {
             foreach (ToggleCheckInfo toggleCheckInfo in toggleCheckInfos)
             {

--- a/Editor/Playa/RendererGroup/SaintsRendererGroupUIToolkit.cs
+++ b/Editor/Playa/RendererGroup/SaintsRendererGroupUIToolkit.cs
@@ -50,9 +50,9 @@ namespace SaintsField.Editor.Playa.RendererGroup
                 },
             };
 
-            bool hasFoldout = _eLayout.HasFlag(ELayout.Foldout) || _eLayout.HasFlag(ELayout.Collapse);
-            bool hasTitle = _eLayout.HasFlag(ELayout.Title) || _eLayout.HasFlag(ELayout.TitleOut);
-            bool hasTab = _eLayout.HasFlag(ELayout.Tab);
+            bool hasFoldout = _eLayout.HasFlagFast(ELayout.Foldout) || _eLayout.HasFlagFast(ELayout.Collapse);
+            bool hasTitle = _eLayout.HasFlagFast(ELayout.Title) || _eLayout.HasFlagFast(ELayout.TitleOut);
+            bool hasTab = _eLayout.HasFlagFast(ELayout.Tab);
 
             Toolbar toolbar = new Toolbar
             {
@@ -124,10 +124,10 @@ namespace SaintsField.Editor.Playa.RendererGroup
                 style =
                 {
                     flexGrow = 1,
-                    flexDirection = _eLayout.HasFlag(ELayout.Horizontal)? FlexDirection.Row :FlexDirection.Column,
+                    flexDirection = _eLayout.HasFlagFast(ELayout.Horizontal)? FlexDirection.Row :FlexDirection.Column,
                 },
             };
-            if (_eLayout.HasFlag(ELayout.Background))
+            if (_eLayout.HasFlagFast(ELayout.Background))
             {
                 body.style.paddingRight = 4;
                 body.style.paddingTop = 1;
@@ -172,9 +172,9 @@ namespace SaintsField.Editor.Playa.RendererGroup
                         borderTopRightRadius = radius,
                     },
                 };
-                if (_eLayout.HasFlag(ELayout.TitleOut))
+                if (_eLayout.HasFlagFast(ELayout.TitleOut))
                 {
-                    if(_eLayout.HasFlag(ELayout.Background))
+                    if(_eLayout.HasFlagFast(ELayout.Background))
                     {
                         // boxed
                         title.style.backgroundColor = new Color(53f / 255, 53f / 255, 53f / 255, 1f);
@@ -199,8 +199,8 @@ namespace SaintsField.Editor.Playa.RendererGroup
                     || hasTitle
                     || !hasTab))
             {
-                bool titleOut = _eLayout.HasFlag(ELayout.TitleOut);
-                bool background = _eLayout.HasFlag(ELayout.Background);
+                bool titleOut = _eLayout.HasFlagFast(ELayout.TitleOut);
+                bool background = _eLayout.HasFlagFast(ELayout.Background);
                 bool fancy = titleOut && background;
                 if (fancy)  // title clickable foldout
                 {
@@ -288,9 +288,9 @@ namespace SaintsField.Editor.Playa.RendererGroup
                         text = _groupPath.Split('/').Last(),
                         value = _foldout,
                     };
-                    if (_eLayout.HasFlag(ELayout.TitleOut))
+                    if (_eLayout.HasFlagFast(ELayout.TitleOut))
                     {
-                        if (_eLayout.HasFlag(ELayout.Background))
+                        if (_eLayout.HasFlagFast(ELayout.Background))
                         {
                             foldout.style.backgroundColor = new Color(53f / 255, 53f / 255, 53f / 255, 1f);
                         }
@@ -429,7 +429,7 @@ namespace SaintsField.Editor.Playa.RendererGroup
             //     labels.ForEach(UIToolkitUtils.FixLabelWidthUIToolkit);
             // }, 200);
 
-            if (_eLayout.HasFlag(ELayout.Tab))
+            if (_eLayout.HasFlagFast(ELayout.Tab))
             {
                 // ReSharper disable once ConvertToLocalFunction
                 EventCallback<AttachToPanelEvent> switchOnAttack = null;
@@ -450,7 +450,7 @@ namespace SaintsField.Editor.Playa.RendererGroup
             root.style.marginBottom = marginBottom;
 
             // sub container has some space left
-            if(_groupPath.Contains('/') && _eLayout.HasFlag(ELayout.Background) && _eLayout.HasFlag(ELayout.Title) && _eLayout.HasFlag(ELayout.TitleOut))
+            if(_groupPath.Contains('/') && _eLayout.HasFlagFast(ELayout.Background) && _eLayout.HasFlagFast(ELayout.Title) && _eLayout.HasFlagFast(ELayout.TitleOut))
             {
                 root.style.marginLeft = 4;
             }

--- a/Editor/Playa/Utils/SaintsEditorUtils.cs
+++ b/Editor/Playa/Utils/SaintsEditorUtils.cs
@@ -96,27 +96,17 @@ namespace SaintsField.Editor.Playa.Utils
         //     return (Array.Empty<string>(), callbackBoolResults);
         // }
 
-        public static void FillResult(ToggleCheckInfo toggleCheckInfo)
+        public static ToggleCheckInfo FillResult(ToggleCheckInfo toggleCheckInfo)
         {
             (IReadOnlyList<string> errors, IReadOnlyList<bool> boolResults) = Util.ConditionChecker(toggleCheckInfo.ConditionInfos, null, null, toggleCheckInfo.Target);
 
-            if (errors.Count > 0)
-            {
-                toggleCheckInfo.Errors = errors;
-                toggleCheckInfo.BoolResults = Array.Empty<bool>();
-                return;
-            }
-
-            toggleCheckInfo.Errors = Array.Empty<string>();
-            toggleCheckInfo.BoolResults = boolResults;
+            return new ToggleCheckInfo(toggleCheckInfo, errors, boolResults);
         }
 
-        public static (bool show, bool disable) GetToggleResult(IReadOnlyList<ToggleCheckInfo> toggleCheckInfos)
+        public static (bool show, bool disable) GetToggleResult(List<ToggleCheckInfo> toggleCheckInfos)
         {
-            if (toggleCheckInfos.Any(each => each.Errors.Count > 0))
-            {
+            if (!toggleCheckInfos.TrueForAll((each) => each.Errors.Count == 0))
                 return (true, false);
-            }
 
             List<bool> showResults = new List<bool>();
             // bool hide = false;
@@ -127,8 +117,11 @@ namespace SaintsField.Editor.Playa.Utils
             // any enable attribute is true: enable; otherwise: not-enable
             bool enable = true;
 
-            foreach (ToggleCheckInfo toggleCheckInfo in toggleCheckInfos.Where(each => each.Errors.Count == 0))
+            foreach (ToggleCheckInfo toggleCheckInfo in toggleCheckInfos)
             {
+                if (toggleCheckInfo.Errors.Count != 0)
+                    continue;
+
                 switch (toggleCheckInfo.Type)
                 {
                     case ToggleType.Show:

--- a/Editor/Playa/Utils/ToggleCheckInfo.cs
+++ b/Editor/Playa/Utils/ToggleCheckInfo.cs
@@ -3,13 +3,32 @@ using SaintsField.Condition;
 
 namespace SaintsField.Editor.Playa.Utils
 {
-    public class ToggleCheckInfo
+    public readonly struct ToggleCheckInfo
     {
-        public ToggleType Type;
-        public IReadOnlyList<ConditionInfo> ConditionInfos;
-        public object Target;
+        public readonly ToggleType Type;
+        public readonly IReadOnlyList<ConditionInfo> ConditionInfos;
+        public readonly object Target;
 
-        public IReadOnlyList<string> Errors;
-        public IReadOnlyList<bool> BoolResults;
+        public readonly IReadOnlyList<string> Errors;
+        public readonly IReadOnlyList<bool> BoolResults;
+
+        public ToggleCheckInfo(ToggleType type, IReadOnlyList<ConditionInfo> conditionInfos, object target)
+        {
+            Type = type;
+            ConditionInfos = conditionInfos;
+            Target = target;
+
+            Errors = null;
+            BoolResults = null;
+        }
+
+        public ToggleCheckInfo(ToggleCheckInfo otherInfo, IReadOnlyList<string> errors, IReadOnlyList<bool> boolResults)
+        {
+            Type = otherInfo.Type;
+            ConditionInfos = otherInfo.ConditionInfos;
+            Target = otherInfo.Target;
+            Errors = errors;
+            BoolResults = boolResults;
+        }
     }
 }

--- a/Editor/SaintsEditor.cs
+++ b/Editor/SaintsEditor.cs
@@ -96,7 +96,7 @@ namespace SaintsField.Editor
             // Debug.Log($"{string.Join(",", pendingSerializedProperties.Keys)}");
             pendingSerializedProperties.Remove("m_Script");
 
-            foreach (int inherentDepth in Enumerable.Range(0, types.Count))
+            for (var inherentDepth = 0; inherentDepth < types.Count; inherentDepth++)
             {
                 Type systemType = types[inherentDepth];
 

--- a/Editor/SaintsEditor.cs
+++ b/Editor/SaintsEditor.cs
@@ -112,7 +112,7 @@ namespace SaintsField.Editor
                              .OrderBy(memberInfo => memberInfo.MetadataToken))  // this is still not the correct order, but... a bit better
                 {
                     // Debug.Log(memberInfo.Name);
-                    IReadOnlyList<IPlayaAttribute> playaAttributes = memberInfo.GetCustomAttributesFast<IPlayaAttribute>();
+                    IReadOnlyList<IPlayaAttribute> playaAttributes = ReflectCache.GetCustomAttributes<IPlayaAttribute>(memberInfo);
 
                     ISaintsLayoutBase[] layoutBases = GetLayoutBases(playaAttributes.OfType<ISaintsLayoutBase>()).ToArray();
                     switch (memberInfo)

--- a/Editor/SaintsEditor.cs
+++ b/Editor/SaintsEditor.cs
@@ -803,7 +803,7 @@ namespace SaintsField.Editor
 
         // private static ISaintsRendererGroup MakeRendererGroup(LayoutInfo layoutInfo)
         // {
-        //     if (layoutInfo.Config.HasFlag(ELayout.Vertical))
+        //     if (layoutInfo.Config.HasFlagFast(ELayout.Vertical))
         //     {
         //         return new VerticalGroup(layoutInfo.Config);
         //     }
@@ -811,11 +811,11 @@ namespace SaintsField.Editor
         // }
         // private static ISaintsRendererGroup MakeRendererGroup(ELayout layoutInfo)
         // {
-        //     if (layoutInfo.HasFlag(ELayout.Tab))
+        //     if (layoutInfo.HasFlagFast(ELayout.Tab))
         //     {
         //         return new SaintsRendererGroup(layoutInfo);
         //     }
-        //     if (layoutInfo.HasFlag(ELayout.Horizontal))
+        //     if (layoutInfo.HasFlagFast(ELayout.Horizontal))
         //     {
         //         return new HorizontalGroup(layoutInfo);
         //     }

--- a/Editor/SaintsEditor.cs
+++ b/Editor/SaintsEditor.cs
@@ -89,7 +89,8 @@ namespace SaintsField.Editor
             object target)
         {
             List<SaintsFieldWithInfo> fieldWithInfos = new List<SaintsFieldWithInfo>();
-            IReadOnlyList<Type> types = ReflectUtils.GetSelfAndBaseTypes(target).Reverse().ToArray();
+            List<Type> types = ReflectUtils.GetSelfAndBaseTypes(target);
+            types.Reverse();
 
             // Dictionary<string, SerializedProperty> pendingSerializedProperties = new Dictionary<string, SerializedProperty>(serializedPropertyDict);
             Dictionary<string, SerializedProperty> pendingSerializedProperties = serializedPropertyDict.ToDictionary(each => each.Key, each => each.Value);

--- a/Editor/SaintsEditor.cs
+++ b/Editor/SaintsEditor.cs
@@ -111,8 +111,7 @@ namespace SaintsField.Editor
                              .OrderBy(memberInfo => memberInfo.MetadataToken))  // this is still not the correct order, but... a bit better
                 {
                     // Debug.Log(memberInfo.Name);
-                    IReadOnlyList<IPlayaAttribute> playaAttributes = memberInfo
-                        .GetCustomAttributes<Attribute>().OfType<IPlayaAttribute>().ToArray();
+                    IReadOnlyList<IPlayaAttribute> playaAttributes = memberInfo.GetCustomAttributesFast<IPlayaAttribute>();
 
                     ISaintsLayoutBase[] layoutBases = GetLayoutBases(playaAttributes.OfType<ISaintsLayoutBase>()).ToArray();
                     switch (memberInfo)

--- a/Editor/TroubleshootEditor/TroubleshootEditorWindow.cs
+++ b/Editor/TroubleshootEditor/TroubleshootEditorWindow.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Reflection;
 using SaintsField.Editor.Core;
 using SaintsField.Editor.Playa;
+using SaintsField.Editor.Utils;
 using SaintsField.Interfaces;
 using SaintsField.Playa;
 using UnityEditor;
@@ -93,7 +94,7 @@ namespace SaintsField.Editor.TroubleshootEditor
                     // {
                     //     yield return null;
                     // }
-                    foreach (CustomEditor customEditor in eachEditorType.GetCustomAttributes<CustomEditor>(true))
+                    foreach (CustomEditor customEditor in eachEditorType.GetCustomAttributesFast<CustomEditor>(true))
                     {
                         yield return null;
                         Type v = (Type)typeof(CustomEditor)
@@ -369,7 +370,7 @@ namespace SaintsField.Editor.TroubleshootEditor
             string error = "";
             List<Attribute> playaAttributes = new List<Attribute>();
 
-            Attribute[] allBaseAttributes = memberInfo.GetCustomAttributes().ToArray();
+            Attribute[] allBaseAttributes = memberInfo.GetCustomAttributesFast();
             if (!isSaintsEditor)
             {
                 playaAttributes.AddRange(allBaseAttributes.Where(each => each is IPlayaAttribute));

--- a/Editor/TroubleshootEditor/TroubleshootEditorWindow.cs
+++ b/Editor/TroubleshootEditor/TroubleshootEditorWindow.cs
@@ -94,7 +94,7 @@ namespace SaintsField.Editor.TroubleshootEditor
                     // {
                     //     yield return null;
                     // }
-                    foreach (CustomEditor customEditor in eachEditorType.GetCustomAttributesFast<CustomEditor>(true))
+                    foreach (CustomEditor customEditor in ReflectCache.GetCustomAttributes<CustomEditor>(eachEditorType, true))
                     {
                         yield return null;
                         Type v = (Type)typeof(CustomEditor)
@@ -370,7 +370,7 @@ namespace SaintsField.Editor.TroubleshootEditor
             string error = "";
             List<Attribute> playaAttributes = new List<Attribute>();
 
-            Attribute[] allBaseAttributes = memberInfo.GetCustomAttributesFast();
+            Attribute[] allBaseAttributes = ReflectCache.GetCustomAttributes(memberInfo);
             if (!isSaintsEditor)
             {
                 playaAttributes.AddRange(allBaseAttributes.Where(each => each is IPlayaAttribute));

--- a/Editor/Utils/GUIColorScoop.cs
+++ b/Editor/Utils/GUIColorScoop.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 
 namespace SaintsField.Editor.Utils
 {
-    public class GUIColorScoop: IDisposable
+    public readonly struct GUIColorScoop: IDisposable
     {
         private readonly Color _color;
 

--- a/Editor/Utils/GUIEnabledScoop.cs
+++ b/Editor/Utils/GUIEnabledScoop.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 
 namespace SaintsField.Editor.Utils
 {
-    public class GUIEnabledScoop: IDisposable
+    public readonly struct GUIEnabledScoop: IDisposable
     {
         private readonly bool defaultValue;
 

--- a/Editor/Utils/ReflectCache.cs
+++ b/Editor/Utils/ReflectCache.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace SaintsField.Editor.Utils
+{
+    public static class ReflectCache
+    {
+        private static readonly Dictionary<AttributesKey, object[]> CustomAttributes = new Dictionary<AttributesKey, object[]>();
+
+        private readonly struct AttributesKey : IEquatable<AttributesKey>
+        {
+            readonly MemberInfo memberInfo;
+            readonly bool inherit;
+            readonly Type type;
+
+            public AttributesKey(MemberInfo memberInfo, bool inherit, Type type = null)
+            {
+                this.memberInfo = memberInfo;
+                this.inherit = inherit;
+                this.type = type;
+            }
+
+            public bool Equals(AttributesKey other) =>
+                Equals(memberInfo, other.memberInfo) && inherit == other.inherit && type == other.type;
+
+            public override bool Equals(object obj) => obj is AttributesKey other && Equals(other);
+
+            public override int GetHashCode() => Util.CombineHashCode(memberInfo, inherit, type);
+        }
+
+        public static Attribute[] GetCustomAttributes(MemberInfo memberInfo, bool inherit = false)
+        {
+            var key = new AttributesKey(memberInfo, inherit);
+            if (CustomAttributes.TryGetValue(key, out var attributes))
+                return (Attribute[])attributes;
+            // ReSharper disable once CoVariantArrayConversion
+            attributes = memberInfo.GetCustomAttributes().ToArray();
+            CustomAttributes[key] = attributes;
+            return (Attribute[])attributes;
+        }
+
+        public static T[] GetCustomAttributes<T>(MemberInfo memberInfo, bool inherit = false) where T : class
+        {
+            var key = new AttributesKey(memberInfo, inherit, typeof(T));
+            if (CustomAttributes.TryGetValue(key, out var attributes))
+                return (T[])attributes;
+            // ReSharper disable once CoVariantArrayConversion
+            attributes = memberInfo.GetCustomAttributes().OfType<T>().ToArray();
+            CustomAttributes[key] = attributes;
+            return (T[])attributes;
+        }
+    }
+}

--- a/Editor/Utils/ReflectCache.cs.meta
+++ b/Editor/Utils/ReflectCache.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: e1934463ba1448ac9611bc0734c79fc4
+timeCreated: 1742316019

--- a/Editor/Utils/ReflectUtils.cs
+++ b/Editor/Utils/ReflectUtils.cs
@@ -85,7 +85,7 @@ namespace SaintsField.Editor.Utils
             }
 
             MethodInfo methodInfo = targetType.GetMethod(fieldName, bindAttr);
-            // Debug.Log($"methodInfo={methodInfo}, fieldName={fieldName}, targetType={targetType}/FlattenHierarchy={bindAttr.HasFlag(BindingFlags.FlattenHierarchy)}");
+            // Debug.Log($"methodInfo={methodInfo}, fieldName={fieldName}, targetType={targetType}/FlattenHierarchy={bindAttr.HasFlagFast(BindingFlags.FlattenHierarchy)}");
             return methodInfo == null ? (GetPropType.NotFound, null) : (GetPropType.Method, methodInfo);
 
         }

--- a/Editor/Utils/ReflectUtils.cs
+++ b/Editor/Utils/ReflectUtils.cs
@@ -166,7 +166,7 @@ namespace SaintsField.Editor.Utils
             Debug.Log($"toFillQueue.Count={toFillQueue.Count}");
 #endif
             // required:
-            foreach (int index in Enumerable.Range(0, methodParams.Count))
+            for (var index = 0; index < methodParams.Count; index++)
             {
                 if (!methodParams[index].IsOptional)
                 {
@@ -210,7 +210,7 @@ namespace SaintsField.Editor.Utils
             // optional:
             if(leftOverQueue.Count > 0)
             {
-                foreach (int index in Enumerable.Range(0, methodParams.Count))
+                for (var index = 0; index < methodParams.Count; index++)
                 {
                     if (leftOverQueue.Count == 0)
                     {

--- a/Editor/Utils/ReflectUtils.cs
+++ b/Editor/Utils/ReflectUtils.cs
@@ -10,6 +10,28 @@ namespace SaintsField.Editor.Utils
 {
     public static class ReflectUtils
     {
+        private static readonly Dictionary<AttributesKey, object[]> CustomAttributes = new Dictionary<AttributesKey , object[]>();
+
+        readonly struct AttributesKey : IEquatable<AttributesKey>
+        {
+            readonly MemberInfo memberInfo;
+            readonly bool inherit;
+            readonly Type type;
+
+            public AttributesKey(MemberInfo memberInfo, bool inherit, Type type = null)
+            {
+                this.memberInfo = memberInfo;
+                this.inherit = inherit;
+                this.type = type;
+            }
+
+            public bool Equals(AttributesKey other) => Equals(memberInfo, other.memberInfo) && inherit == other.inherit && type == other.type;
+
+            public override bool Equals(object obj) => obj is AttributesKey other && Equals(other);
+
+            public override int GetHashCode() => Util.CombineHashCode(memberInfo, inherit, type);
+        }
+
         public static IReadOnlyList<Type> GetSelfAndBaseTypes(object target)
         {
             return GetSelfAndBaseTypesFromType(target.GetType());
@@ -443,6 +465,28 @@ namespace SaintsField.Editor.Utils
             FieldInfo wrapFieldInfo = wrapPropType.GetField(prop, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.FlattenHierarchy);
             Debug.Assert(wrapFieldInfo != null);
             return wrapFieldInfo.FieldType;
+        }
+
+        public static Attribute[] GetCustomAttributesFast(this MemberInfo memberInfo, bool inherit = false)
+        {
+            var key = new AttributesKey(memberInfo, inherit);
+            if (CustomAttributes.TryGetValue(key, out var attributes))
+                return (Attribute[])attributes;
+            // ReSharper disable once CoVariantArrayConversion
+            attributes = memberInfo.GetCustomAttributes().ToArray();
+            CustomAttributes[key] = attributes;
+            return (Attribute[])attributes;
+        }
+
+        public static T[] GetCustomAttributesFast<T>(this MemberInfo memberInfo, bool inherit = false) where T : class
+        {
+            var key = new AttributesKey(memberInfo, inherit, typeof(T));
+            if (CustomAttributes.TryGetValue(key, out var attributes))
+                return (T[])attributes;
+            // ReSharper disable once CoVariantArrayConversion
+            attributes = memberInfo.GetCustomAttributes().OfType<T>().ToArray();
+            CustomAttributes[key] = attributes;
+            return (T[])attributes;
         }
 
         public static Type GetDictionaryType(Type type)

--- a/Editor/Utils/ReflectUtils.cs
+++ b/Editor/Utils/ReflectUtils.cs
@@ -32,21 +32,21 @@ namespace SaintsField.Editor.Utils
             public override int GetHashCode() => Util.CombineHashCode(memberInfo, inherit, type);
         }
 
-        public static IReadOnlyList<Type> GetSelfAndBaseTypes(object target)
+        public static List<Type> GetSelfAndBaseTypes(object target)
         {
             return GetSelfAndBaseTypesFromType(target.GetType());
         }
 
-        public static IReadOnlyList<Type> GetSelfAndBaseTypesFromType(Type thisType)
+        public static List<Type> GetSelfAndBaseTypesFromType(Type thisType)
         {
-            List<Type> types = new List<Type>
+            List<Type> types = new List<Type>(1)
             {
                 thisType,
             };
 
-            while (types.Last().BaseType != null)
+            while (types[types.Count - 1].BaseType != null)
             {
-                types.Add(types.Last().BaseType);
+                types.Add(types[types.Count - 1].BaseType);
             }
 
             // types.Reverse();

--- a/Editor/Utils/RenderTextureActiveScoop.cs
+++ b/Editor/Utils/RenderTextureActiveScoop.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 
 namespace SaintsField.Editor.Utils
 {
-    public class RenderTextureActiveScoop: IDisposable
+    public readonly struct RenderTextureActiveScoop: IDisposable
     {
         private readonly RenderTexture _previousRenderTexture;
 

--- a/Editor/Utils/RenderTextureTemporaryScoop.cs
+++ b/Editor/Utils/RenderTextureTemporaryScoop.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 
 namespace SaintsField.Editor.Utils
 {
-    public class RenderTextureTemporaryScoop: IDisposable
+    public readonly struct RenderTextureTemporaryScoop: IDisposable
     {
         public readonly RenderTexture RenderTex;
 

--- a/Editor/Utils/SerializedUtils.cs
+++ b/Editor/Utils/SerializedUtils.cs
@@ -47,8 +47,8 @@ namespace SaintsField.Editor.Utils
         public static (FieldOrProp fieldOrProp, object parent) GetFieldInfoAndDirectParent(SerializedProperty property)
         {
             string originPath = property.propertyPath;
-            IReadOnlyList<string> propPaths = originPath.Split(pathSplitSeparator);
-            (bool arrayTrim, IReadOnlyList<string> propPathSegments) = TrimEndArray(propPaths);
+            string[] propPaths = originPath.Split(pathSplitSeparator);
+            (bool arrayTrim, string[] propPathSegments) = TrimEndArray(propPaths);
             if (arrayTrim)
             {
                 propPaths = propPathSegments;
@@ -58,7 +58,7 @@ namespace SaintsField.Editor.Utils
             FieldOrProp fieldOrProp = default;
 
             bool preNameIsArray = false;
-            for (int propIndex = 0; propIndex < propPaths.Count; propIndex++)
+            for (int propIndex = 0; propIndex < propPaths.Length; propIndex++)
             {
                 string propSegName = propPaths[propIndex];
                 // Debug.Log($"check key {propSegName}");
@@ -134,7 +134,7 @@ namespace SaintsField.Editor.Utils
         {
             string[] paths = property.propertyPath.Split(pathSplitSeparator);
 
-            (bool _, IReadOnlyList<string> propPathSegments) = TrimEndArray(paths);
+            (bool _, string[] propPathSegments) = TrimEndArray(paths);
             return $"{property.serializedObject.targetObject.GetInstanceID()}_{string.Join(".", propPathSegments)}";
         }
 
@@ -143,7 +143,7 @@ namespace SaintsField.Editor.Utils
             // Debug.Log(property.propertyPath);
             string[] paths = property.propertyPath.Split(pathSplitSeparator);
 
-            (bool arrayTrim, IReadOnlyList<string> propPathSegments) = TrimEndArray(paths);
+            (bool arrayTrim, string[] propPathSegments) = TrimEndArray(paths);
             if (!arrayTrim)
             {
                 return ($"{property.propertyPath} is not an array/list.", null);
@@ -164,10 +164,10 @@ namespace SaintsField.Editor.Utils
             return ("", arrayProp);
         }
 
-        private static (bool trimed, IReadOnlyList<string> propPathSegs) TrimEndArray(IReadOnlyList<string> propPathSegments)
+        private static (bool trimed, string[] propPathSegs) TrimEndArray(string[] propPathSegments)
         {
 
-            int usePathLength = propPathSegments.Count;
+            int usePathLength = propPathSegments.Length;
 
             if (usePathLength <= 2)
             {
@@ -183,9 +183,8 @@ namespace SaintsField.Editor.Utils
             }
 
             // old Unity does not have SkipLast
-            List<string> propPaths = new List<string>(propPathSegments);
-            propPaths.RemoveAt(propPaths.Count - 1);
-            propPaths.RemoveAt(propPaths.Count - 1);
+            string[] propPaths = new string[usePathLength - 2];
+            Array.Copy(propPathSegments, 0, propPaths, 0, usePathLength - 2);
             return (true, propPaths);
         }
 

--- a/Editor/Utils/SerializedUtils.cs
+++ b/Editor/Utils/SerializedUtils.cs
@@ -23,11 +23,25 @@ namespace SaintsField.Editor.Utils
             return property.FindPropertyRelative($"<{propName}>k__BackingField");
         }
 
-        public struct FieldOrProp
+        public readonly struct FieldOrProp
         {
-            public bool IsField;
-            public FieldInfo FieldInfo;
-            public PropertyInfo PropertyInfo;
+            public readonly bool IsField;
+            public readonly FieldInfo FieldInfo;
+            public readonly PropertyInfo PropertyInfo;
+
+            public FieldOrProp(FieldInfo fieldInfo)
+            {
+                IsField = true;
+                FieldInfo = fieldInfo;
+                PropertyInfo = null;
+            }
+
+            public FieldOrProp(PropertyInfo propertyInfo)
+            {
+                IsField = false;
+                FieldInfo = null;
+                PropertyInfo = propertyInfo;
+            }
         }
 
         public static (FieldOrProp fieldOrProp, object parent) GetFieldInfoAndDirectParent(SerializedProperty property)
@@ -209,12 +223,7 @@ namespace SaintsField.Editor.Utils
                 if (field != null)
                 {
                     // Debug.Log($"return field {field.Name} by {name}");
-                    return new FieldOrProp
-                    {
-                        IsField = true,
-                        PropertyInfo = null,
-                        FieldInfo = field,
-                    };
+                    return new FieldOrProp(field);
                 }
 
                 PropertyInfo property = type.GetProperty(name, BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance);
@@ -222,12 +231,7 @@ namespace SaintsField.Editor.Utils
                 {
                     // return property.GetValue(source, null);
                     // Debug.Log($"return prop {property.Name} by {name}");
-                    return new FieldOrProp
-                    {
-                        IsField = false,
-                        PropertyInfo = property,
-                        FieldInfo = null,
-                    };
+                    return new FieldOrProp(property);
                 }
 
                 type = type.BaseType;

--- a/Editor/Utils/SerializedUtils.cs
+++ b/Editor/Utils/SerializedUtils.cs
@@ -203,7 +203,7 @@ namespace SaintsField.Editor.Utils
             // Debug.Log(fieldOrProp.FieldInfo.GetCustomAttributes(typeof(ISaintsAttribute)));
             // Debug.Log(fieldOrProp.FieldInfo.GetCustomAttributes());
             MemberInfo memberInfo = fieldOrProp.IsField ? (MemberInfo)fieldOrProp.FieldInfo : fieldOrProp.PropertyInfo;
-            return (memberInfo.GetCustomAttributesFast<T>(), sourceObj);
+            return (ReflectCache.GetCustomAttributes<T>(memberInfo), sourceObj);
         }
 
         private static FieldOrProp GetFileOrProp(object source, string name)

--- a/Editor/Utils/SerializedUtils.cs
+++ b/Editor/Utils/SerializedUtils.cs
@@ -202,14 +202,8 @@ namespace SaintsField.Editor.Utils
             // this does not work with interface type
             // Debug.Log(fieldOrProp.FieldInfo.GetCustomAttributes(typeof(ISaintsAttribute)));
             // Debug.Log(fieldOrProp.FieldInfo.GetCustomAttributes());
-            T[] attributes = fieldOrProp.IsField
-                ? fieldOrProp.FieldInfo.GetCustomAttributes()
-                    .OfType<T>()
-                    .ToArray()
-                : fieldOrProp.PropertyInfo.GetCustomAttributes()
-                    .OfType<T>()
-                    .ToArray();
-            return (attributes, sourceObj);
+            MemberInfo memberInfo = fieldOrProp.IsField ? (MemberInfo)fieldOrProp.FieldInfo : fieldOrProp.PropertyInfo;
+            return (memberInfo.GetCustomAttributesFast<T>(), sourceObj);
         }
 
         private static FieldOrProp GetFileOrProp(object source, string name)

--- a/Editor/Utils/Util.cs
+++ b/Editor/Utils/Util.cs
@@ -946,7 +946,7 @@ namespace SaintsField.Editor.Utils
             // MemberInfo accMemberInfo = memberInfo;
             (string error, T result) thisResult = ("No Attributes", defaultValue);
 
-            foreach (string attrName in by.Split('.'))
+            foreach (string attrName in by.Split(SerializedUtils.pathSplitSeparator))
             {
                 MemberInfo accMemberInfo = ReflectUtils.GetSelfAndBaseTypes(accParent)
                     .SelectMany(type => type

--- a/Editor/Utils/Util.cs
+++ b/Editor/Utils/Util.cs
@@ -69,22 +69,14 @@ namespace SaintsField.Editor.Utils
                 // Debug.Log(actualFieldInfo);
                 if (actualFieldInfo != null)
                 {
-                    return new SerializedUtils.FieldOrProp
-                    {
-                        IsField = true,
-                        FieldInfo = actualFieldInfo,
-                    };
+                    return new SerializedUtils.FieldOrProp(actualFieldInfo);
                 }
 
                 PropertyInfo actualPropertyInfo = selfAndBaseType.GetProperty(propName, bind);
                 // Debug.Log(actualPropertyInfo);
                 if (actualPropertyInfo != null)
                 {
-                    return new SerializedUtils.FieldOrProp
-                    {
-                        IsField = false,
-                        PropertyInfo = actualPropertyInfo,
-                    };
+                    return new SerializedUtils.FieldOrProp(actualPropertyInfo);
                 }
                 // Debug.Assert(actualFieldInfo != null);
                 // actualFieldInfo.SetValue(wrapProp, curItem);

--- a/Editor/Utils/Util.cs
+++ b/Editor/Utils/Util.cs
@@ -1107,39 +1107,41 @@ namespace SaintsField.Editor.Utils
             };
         }
 
-        public static int CombineHashCode(object object1, object object2)
+        public static int CombineHashCode<T1, T2>(T1 object1, T2 object2)
         {
             // HashCode.Combine does not exist in old Unity
 #if UNITY_2021_1_OR_NEWER
             return HashCode.Combine(object1, object2);
 #else
-            return MockHashCode(new[] {object1, object2});
+            var hashCode = 17;
+            hashCode *= 31 + object1?.GetHashCode() ?? 0;
+            hashCode *= 31 + object2?.GetHashCode() ?? 0;
+            return hashCode;
 #endif
         }
-        public static int CombineHashCode(object object1, object object2, object object3)
+        public static int CombineHashCode<T1, T2, T3>(T1 object1, T2 object2, T3 object3)
         {
             // HashCode.Combine does not exist in old Unity
 #if UNITY_2021_1_OR_NEWER
             return HashCode.Combine(object1, object2, object3);
 #else
-            return MockHashCode(new[] {object1, object2, object3});
+            var hashCode = CombineHashCode(object1, object2);
+            hashCode *= 31 + object3?.GetHashCode() ?? 0;
+            return hashCode;
 #endif
         }
 
-        public static int CombineHashCode(object object1, object object2, object object3, object object4)
+        public static int CombineHashCode<T1, T2, T3, T4>(T1 object1, T2 object2, T3 object3, T4 object4)
         {
             // HashCode.Combine does not exist in old Unity
 #if UNITY_2021_1_OR_NEWER
             return HashCode.Combine(object1, object2, object3, object4);
 #else
-            return MockHashCode(new[] {object1, object2, object3, object4});
+            var hashCode = CombineHashCode(object1, object2, object3);
+            hashCode *= 31 + object4?.GetHashCode() ?? 0;
+            return hashCode;
 #endif
         }
-
-#if !UNITY_2021_1_OR_NEWER
-        private static int MockHashCode(object[] objects) =>
-            objects.Aggregate(17, (current, obj) => current * 31 + (obj?.GetHashCode() ?? 0));
-#endif
 
         public static (string error, int index, object value) GetValue(SerializedProperty property, MemberInfo fieldInfo, object parent)
         {

--- a/Editor/Utils/Util.cs
+++ b/Editor/Utils/Util.cs
@@ -821,8 +821,8 @@ namespace SaintsField.Editor.Utils
 
         private static bool ConditionEditModeChecker(EMode editorMode)
         {
-            bool editorRequiresEdit = editorMode.HasFlag(EMode.Edit);
-            bool editorRequiresPlay = editorMode.HasFlag(EMode.Play);
+            bool editorRequiresEdit = editorMode.HasFlagFast(EMode.Edit);
+            bool editorRequiresPlay = editorMode.HasFlagFast(EMode.Play);
             // ReSharper disable once ConvertIfStatementToSwitchStatement
             if(editorRequiresEdit && editorRequiresPlay)
             {

--- a/Runtime/EGetComp.cs
+++ b/Runtime/EGetComp.cs
@@ -9,4 +9,9 @@ namespace SaintsField
         ForceResign = 1,
         NoResignButton = 1 << 1,
     }
+
+    public static class EGetCompExtensions
+    {
+        public static bool HasFlagFast(this EGetComp lhs, EGetComp rhs) => (lhs & rhs) != 0;
+    }
 }

--- a/Runtime/EMode.cs
+++ b/Runtime/EMode.cs
@@ -8,4 +8,9 @@ namespace SaintsField
         Edit = 1,
         Play = 1 << 1,
     }
+
+    public static class EModeExtensions
+    {
+        public static bool HasFlagFast(this EMode lhs, EMode rhs) => (lhs & rhs) != 0;
+    }
 }

--- a/Runtime/EPick.cs
+++ b/Runtime/EPick.cs
@@ -9,4 +9,9 @@ namespace SaintsField
         Scene = 1 << 1,
         // Maybe: children? etc.
     }
+
+    public static class EPickExtensions
+    {
+        public static bool HasFlagFast(this EPick lhs, EPick rhs) => (lhs & rhs) != 0;
+    }
 }

--- a/Runtime/EXP.cs
+++ b/Runtime/EXP.cs
@@ -23,4 +23,9 @@ namespace SaintsField
         JustPicker = NoInitSign | NoAutoResign | NoResignButton | NoMessage,
         Message = NoAutoResign | NoResignButton,
     }
+
+    public static class EXPExtensions
+    {
+        public static bool HasFlagFast(this EXP lhs, EXP rhs) => (lhs & rhs) != 0;
+    }
 }

--- a/Runtime/GetByXPathAttribute.cs
+++ b/Runtime/GetByXPathAttribute.cs
@@ -50,21 +50,21 @@ namespace SaintsField
 
         protected void ParseOptions(EXP config)
         {
-            InitSign = !config.HasFlag(EXP.NoInitSign);
-            UsePickerButton = !config.HasFlag(EXP.NoPicker);
-            KeepOriginalPicker = !UsePickerButton || config.HasFlag(EXP.KeepOriginalPicker);
-            AutoResignToValue = !config.HasFlag(EXP.NoAutoResignToValue);
-            AutoResignToNull = !config.HasFlag(EXP.NoAutoResignToNull);
+            InitSign = !config.HasFlagFast(EXP.NoInitSign);
+            UsePickerButton = !config.HasFlagFast(EXP.NoPicker);
+            KeepOriginalPicker = !UsePickerButton || config.HasFlagFast(EXP.KeepOriginalPicker);
+            AutoResignToValue = !config.HasFlagFast(EXP.NoAutoResignToValue);
+            AutoResignToNull = !config.HasFlagFast(EXP.NoAutoResignToNull);
             if (AutoResignToValue && AutoResignToNull)
             {
                 UseResignButton = false;
             }
             else
             {
-                UseResignButton = !config.HasFlag(EXP.NoResignButton);
+                UseResignButton = !config.HasFlagFast(EXP.NoResignButton);
             }
 
-            if (config.HasFlag(EXP.NoMessage))
+            if (config.HasFlagFast(EXP.NoMessage))
             {
                 UseErrorMessage = false;
             }
@@ -73,7 +73,7 @@ namespace SaintsField
                 UseErrorMessage = !UseResignButton;
             }
 
-            ForceReOrder = config.HasFlag(EXP.ForceReOrder);
+            ForceReOrder = config.HasFlagFast(EXP.ForceReOrder);
         }
 
         public GetByXPathAttribute(EXP config, params string[] ePaths)

--- a/Runtime/GetComponentByPathAttribute.cs
+++ b/Runtime/GetComponentByPathAttribute.cs
@@ -90,8 +90,8 @@ namespace SaintsField
 
         public GetComponentByPathAttribute(EGetComp config, string path, params string[] paths): this(TranslateConfig(config), path, paths)
         {
-            ForceResign = config.HasFlag(EGetComp.ForceResign);
-            ResignButton = !config.HasFlag(EGetComp.NoResignButton);
+            ForceResign = config.HasFlagFast(EGetComp.ForceResign);
+            ResignButton = !config.HasFlagFast(EGetComp.NoResignButton);
             RawPaths = paths
                 .Prepend(path)
                 .ToArray();
@@ -134,7 +134,7 @@ namespace SaintsField
         private static EXP TranslateConfig(EGetComp config)
         {
             EXP exp = EXP.NoPicker;
-            if (config.HasFlag(EGetComp.ForceResign))
+            if (config.HasFlagFast(EGetComp.ForceResign))
             {
                 // do nothing
             }
@@ -144,7 +144,7 @@ namespace SaintsField
                 exp |= EXP.NoAutoResignToNull;
             }
 
-            if (config.HasFlag(EGetComp.NoResignButton))
+            if (config.HasFlagFast(EGetComp.NoResignButton))
             {
                 exp |= EXP.NoResignButton;
             }

--- a/Runtime/Playa/ELayout.cs
+++ b/Runtime/Playa/ELayout.cs
@@ -18,4 +18,9 @@ namespace SaintsField.Playa
         FoldoutBox = Background | Title | TitleOut | Foldout,
         CollapseBox = Background | Title | TitleOut | Collapse,
     }
+
+    public static class ELayoutExtensions
+    {
+        public static bool HasFlagFast(this ELayout lhs, ELayout rhs) => (lhs & rhs) != 0;
+    }
 }

--- a/Runtime/SaintsDictionaryBase.cs
+++ b/Runtime/SaintsDictionaryBase.cs
@@ -39,7 +39,7 @@ namespace SaintsField
             if (keyCount < valueCount)
             {
                 int addCount = valueCount - keyCount;
-                foreach (int _ in Enumerable.Range(0, addCount))
+                for (int i = 0; i < addCount; i++)
                 {
                     SerializedKeys.Add(default);
                 }
@@ -48,7 +48,7 @@ namespace SaintsField
             else if (keyCount > valueCount)
             {
                 int addCount = keyCount - valueCount;
-                foreach (int _ in Enumerable.Range(0, addCount))
+                for (int i = 0; i < addCount; i++)
                 {
                     SerializedValues.Add(default);
                 }
@@ -79,7 +79,7 @@ namespace SaintsField
             //
             // }
 
-            foreach (int index in Enumerable.Range(0, SerializedKeys.Count))
+            for (var index = 0; index < SerializedKeys.Count; index++)
             {
                 TKey key = SerializedKeys[index];
                 TValue value = SerializedValues.Count > index ? SerializedValues[index] : default;


### PR DESCRIPTION
This should be reviewed commit-by-commit. I only tested this with Unity 2019 and Unity 6 with `SAINTSFIELD_EDITOR_APPLY` enabled. All seems to be working in my testing, but please double-check before merging.

The main optimization here is https://github.com/TylerTemp/SaintsField/commit/ab36c33484a6bd590d26aaa13c951f040e2c719c, which adds a cache for the attributes on all members to avoid repeated reflection lookups.

Most other optimizations are minor and primarily focused on reducing editor allocations.

In my Unity 2019 project, I have a component with around 20 fields with SaintsField attributes, and this PR brings the time spent drawing the component from ~300ms w/ 29 MB of alloc (!!!) to ~17ms w/ 0.9 MB of alloc.

I still don't find this acceptable. There's a *lot* of work to do performance-wise, especially regarding the amount of LINQ used, and there's likely some more reflection caching to be done, but this is a significant improvement. Ideally, all usages of LINQ (within reason) should be removed as, for the exception of a couple of methods, all of them are *much* slower and allocate *kilobytes* of memory per call compared to using traditional if statements and for loops or methods built into the individual types (e.g. `List<T>.TrueForAll`).