### PR TITLE
Fix NullRef exceptions on UI Toolkit managed reference property attribute drawer fill

### DIFF
--- a/Editor/Drawers/SaintsRowDrawer/SaintsRowAttributeDrawerUIToolkit.cs
+++ b/Editor/Drawers/SaintsRowDrawer/SaintsRowAttributeDrawerUIToolkit.cs
@@ -183,7 +183,9 @@ namespace SaintsField.Editor.Drawers.SaintsRowDrawer
                         {
                             // Debug.Log($"{property.propertyPath} Changed {curId} -> {property.managedReferenceId}/{property.managedReferenceFieldTypename}");
                             root.userData = property.managedReferenceId;
-                            root.Clear();
+
+                            VisualElement actualContainer = root.Q<VisualElement>(NameActualContainer(property));
+                            actualContainer.Clear();
 
                             SerializedProperty newProp = property.serializedObject.FindProperty(propPath);
 


### PR DESCRIPTION
Attempts to fix #290. Not entirely sure about the full code flow here but it seemed like we were erroneously clearing this whole root element instead of just the actual property container in this scheduled call.

My first contribution, please let me know if there's anything else needed or feel free to adjust/discard this if there's a better fix. I just needed to get this working :)