### PR TITLE
General improvements to the FlagsDropdownElement implementation to be closer to the Unity implementation for display

### DIFF
--- a/Editor/Drawers/ShaderDrawers/ShaderParamDrawer/ShaderParamIntElement.cs
+++ b/Editor/Drawers/ShaderDrawers/ShaderParamDrawer/ShaderParamIntElement.cs
@@ -42,7 +42,7 @@ namespace SaintsField.Editor.Drawers.ShaderDrawers.ShaderParamDrawer
                 }
             }
 
-            Label.text = $"<color=red>?</color> {(CachedValue == -1? "": $"({CachedValue})")}";
+            Label.text = $"<color=red>?</color> {(CachedValue == null? "": $"({CachedValue})")}";
         }
     }
 }

--- a/Editor/UIToolkitElements/IntDropdownField.cs
+++ b/Editor/UIToolkitElements/IntDropdownField.cs
@@ -9,7 +9,7 @@ namespace SaintsField.Editor.UIToolkitElements
     {
         protected readonly Label Label;
 
-        protected int CachedValue = -1;
+        protected int? CachedValue = null;
 
         public readonly Button Button;
 
@@ -31,7 +31,7 @@ namespace SaintsField.Editor.UIToolkitElements
 
         public int value
         {
-            get => CachedValue;
+            get => CachedValue ?? 0;
             set
             {
                 if (CachedValue == value)
@@ -58,6 +58,8 @@ namespace SaintsField.Editor.UIToolkitElements
             Button = intDropdownElement.Button;
             AddToClassList(alignedFieldUssClassName);
             AddToClassList(SaintsPropertyDrawer.ClassAllowDisable);
+
+            this.style.flexShrink = 1;
         }
     }
 }


### PR DESCRIPTION
fix: FlagsDropdownElement not showing the actual name for NOTHING or EVERYTHING set in the flags enum if set by the developer
fix: FlagsDropdownElement should have a cap on its width via flexShrink
fix: FlagsDropdownElement did not attempt to collapse down flags that were contained within higher flags (up,down,vertical,left,right,horizontal should be collapsed to just vertical,horizontal)
fix: FlagsDropdownElement did not use a tooltip if everything got too long
fix: FlagsDropdownElement did not showing EVERYTHING if the enum value was -1 since CachedValue was instantiated to -1, now it's a nullable int