### PR TITLE
Fix new gameobjects being spawned whenever a property is reset

### DIFF
--- a/Editor/Utils/UIToolkitUtils.cs
+++ b/Editor/Utils/UIToolkitUtils.cs
@@ -2559,7 +2559,7 @@ namespace SaintsField.Editor.Utils
                             Debug.LogError(e);
                         }
 
-                        // UnityEngine.Object.DestroyImmediate(go);
+                        UnityEngine.Object.DestroyImmediate(go);
                     });
 
                 }));


### PR DESCRIPTION
just uncommented a line from when it was initially implemented - looks like it was done accidentally when reset support for ScriptableObjects was added.

Fixes issue #370 