### PR TITLE
6.5 Fixes

### DIFF
--- a/Editor/Core/InsideSaintsFieldScoop.cs
+++ b/Editor/Core/InsideSaintsFieldScoop.cs
@@ -10,20 +10,20 @@ namespace SaintsField.Editor.Core
     {
         public readonly struct PropertyKey : IEquatable<PropertyKey>
         {
-#if UNITY_6000_5_OR_NEWER
+#if UNITY_6000_4_OR_NEWER
             public readonly ulong ObjectHash;
 #else
             public readonly int ObjectHash;
 #endif
             public readonly string PropertyPath;
 
-#if UNITY_6000_5_OR_NEWER
+#if UNITY_6000_4_OR_NEWER
             public PropertyKey(EntityId entityId, string propertyPath)
 #else
             public PropertyKey(int objectHash, string propertyPath)
 #endif
             {
-#if UNITY_6000_5_OR_NEWER
+#if UNITY_6000_4_OR_NEWER
                 ObjectHash = EntityId.ToULong(entityId);
 #else
                 ObjectHash = objectHash;
@@ -55,7 +55,7 @@ namespace SaintsField.Editor.Core
         private readonly PropertyKey _property;
 
         public static PropertyKey MakeKey(SerializedProperty property) => new PropertyKey(
-#if UNITY_6000_5_OR_NEWER
+#if UNITY_6000_4_OR_NEWER
             property.serializedObject.targetObject.GetEntityId(),
 #else
             property.serializedObject.targetObject.GetInstanceID(),

--- a/Editor/Core/InsideSaintsFieldScoop.cs
+++ b/Editor/Core/InsideSaintsFieldScoop.cs
@@ -10,12 +10,24 @@ namespace SaintsField.Editor.Core
     {
         public readonly struct PropertyKey : IEquatable<PropertyKey>
         {
+#if UNITY_6000_5_OR_NEWER
+            public readonly ulong ObjectHash;
+#else
             public readonly int ObjectHash;
+#endif
             public readonly string PropertyPath;
 
+#if UNITY_6000_5_OR_NEWER
+            public PropertyKey(EntityId entityId, string propertyPath)
+#else
             public PropertyKey(int objectHash, string propertyPath)
+#endif
             {
+#if UNITY_6000_5_OR_NEWER
+                ObjectHash = EntityId.ToULong(entityId);
+#else
                 ObjectHash = objectHash;
+#endif
                 PropertyPath = propertyPath;
             }
 
@@ -43,7 +55,11 @@ namespace SaintsField.Editor.Core
         private readonly PropertyKey _property;
 
         public static PropertyKey MakeKey(SerializedProperty property) => new PropertyKey(
+#if UNITY_6000_5_OR_NEWER
+            property.serializedObject.targetObject.GetEntityId(),
+#else
             property.serializedObject.targetObject.GetInstanceID(),
+#endif
             property.propertyPath
         );
 

--- a/Editor/Drawers/AssetPreviewDrawer/AssetPreviewAttributeDrawer.cs
+++ b/Editor/Drawers/AssetPreviewDrawer/AssetPreviewAttributeDrawer.cs
@@ -39,7 +39,11 @@ namespace SaintsField.Editor.Drawers.AssetPreviewDrawer
             if(_previewTexture == null || _previewTexture.width == 1)
             {
                 // Debug.Log($"load preview {target}");
+#if UNITY_6000_5_OR_NEWER
+                if(AssetPreview.IsLoadingAssetPreview(target.GetEntityId()))
+#else
                 if(AssetPreview.IsLoadingAssetPreview(target.GetInstanceID()))
+#endif
                 {
                     return null;
                 }

--- a/Editor/Drawers/AssetPreviewDrawer/AssetPreviewAttributeDrawer.cs
+++ b/Editor/Drawers/AssetPreviewDrawer/AssetPreviewAttributeDrawer.cs
@@ -39,7 +39,7 @@ namespace SaintsField.Editor.Drawers.AssetPreviewDrawer
             if(_previewTexture == null || _previewTexture.width == 1)
             {
                 // Debug.Log($"load preview {target}");
-#if UNITY_6000_5_OR_NEWER
+#if UNITY_6000_4_OR_NEWER
                 if(AssetPreview.IsLoadingAssetPreview(target.GetEntityId()))
 #else
                 if(AssetPreview.IsLoadingAssetPreview(target.GetInstanceID()))

--- a/Editor/Drawers/CustomPicker/FieldTypeDrawer/FieldTypeAttributeDrawer.cs
+++ b/Editor/Drawers/CustomPicker/FieldTypeDrawer/FieldTypeAttributeDrawer.cs
@@ -55,7 +55,7 @@ namespace SaintsField.Editor.Drawers.CustomPicker.FieldTypeDrawer
                     return false;
                 }
 
-#if UNITY_6000_5_OR_NEWER
+#if UNITY_6000_4_OR_NEWER
                 EntityId targetInstanceId = target.GetEntityId();
 #else
                 int targetInstanceId = target.GetInstanceID();
@@ -84,7 +84,7 @@ namespace SaintsField.Editor.Drawers.CustomPicker.FieldTypeDrawer
                 }
 
                 // Debug.Log($"{itemObject} ?= {target} => {itemToOriginTypeValue.GetInstanceID() == targetInstanceId}");
-#if UNITY_6000_5_OR_NEWER
+#if UNITY_6000_4_OR_NEWER
                 return itemToOriginTypeValue.GetEntityId() == targetInstanceId;
 #else
                 return itemToOriginTypeValue.GetInstanceID() == targetInstanceId;

--- a/Editor/Drawers/CustomPicker/FieldTypeDrawer/FieldTypeAttributeDrawer.cs
+++ b/Editor/Drawers/CustomPicker/FieldTypeDrawer/FieldTypeAttributeDrawer.cs
@@ -55,7 +55,11 @@ namespace SaintsField.Editor.Drawers.CustomPicker.FieldTypeDrawer
                     return false;
                 }
 
+#if UNITY_6000_5_OR_NEWER
+                EntityId targetInstanceId = target.GetEntityId();
+#else
                 int targetInstanceId = target.GetInstanceID();
+#endif
                 if (itemInfo.InstanceID == targetInstanceId)
                 {
                     return true;
@@ -80,7 +84,11 @@ namespace SaintsField.Editor.Drawers.CustomPicker.FieldTypeDrawer
                 }
 
                 // Debug.Log($"{itemObject} ?= {target} => {itemToOriginTypeValue.GetInstanceID() == targetInstanceId}");
+#if UNITY_6000_5_OR_NEWER
+                return itemToOriginTypeValue.GetEntityId() == targetInstanceId;
+#else
                 return itemToOriginTypeValue.GetInstanceID() == targetInstanceId;
+#endif
             }
 
             protected override void OnSelect(ItemInfo itemInfo)

--- a/Editor/Drawers/CustomPicker/RequireTypeDrawer/RequireTypeAttributeDrawer.cs
+++ b/Editor/Drawers/CustomPicker/RequireTypeDrawer/RequireTypeAttributeDrawer.cs
@@ -57,7 +57,7 @@ namespace SaintsField.Editor.Drawers.CustomPicker.RequireTypeDrawer
                 Object itemObject = itemInfo.Object;
                 Debug.Assert(itemObject, itemObject);
 
-#if UNITY_6000_5_OR_NEWER
+#if UNITY_6000_4_OR_NEWER
                 EntityId targetInstanceId = target.GetEntityId();
 #else
                 int targetInstanceId = target.GetInstanceID();
@@ -75,7 +75,7 @@ namespace SaintsField.Editor.Drawers.CustomPicker.RequireTypeDrawer
                 Object itemToOriginTypeValue = Util.GetTypeFromObj(itemObject, _fieldType);
 
                 // Debug.Log($"{itemObject} ?= {target} => {itemToOriginTypeValue.GetInstanceID() == targetInstanceId}");
-#if UNITY_6000_5_OR_NEWER
+#if UNITY_6000_4_OR_NEWER
                 return itemToOriginTypeValue.GetEntityId() == targetInstanceId;
 #else
                 return itemToOriginTypeValue.GetInstanceID() == targetInstanceId;

--- a/Editor/Drawers/CustomPicker/RequireTypeDrawer/RequireTypeAttributeDrawer.cs
+++ b/Editor/Drawers/CustomPicker/RequireTypeDrawer/RequireTypeAttributeDrawer.cs
@@ -57,7 +57,11 @@ namespace SaintsField.Editor.Drawers.CustomPicker.RequireTypeDrawer
                 Object itemObject = itemInfo.Object;
                 Debug.Assert(itemObject, itemObject);
 
+#if UNITY_6000_5_OR_NEWER
+                EntityId targetInstanceId = target.GetEntityId();
+#else
                 int targetInstanceId = target.GetInstanceID();
+#endif
                 if (itemInfo.InstanceID == targetInstanceId)
                 {
                     return true;
@@ -71,7 +75,11 @@ namespace SaintsField.Editor.Drawers.CustomPicker.RequireTypeDrawer
                 Object itemToOriginTypeValue = Util.GetTypeFromObj(itemObject, _fieldType);
 
                 // Debug.Log($"{itemObject} ?= {target} => {itemToOriginTypeValue.GetInstanceID() == targetInstanceId}");
+#if UNITY_6000_5_OR_NEWER
+                return itemToOriginTypeValue.GetEntityId() == targetInstanceId;
+#else
                 return itemToOriginTypeValue.GetInstanceID() == targetInstanceId;
+#endif
             }
 
             protected override void OnSelect(ItemInfo itemInfo)

--- a/Editor/Drawers/CustomPicker/ResourcePathDrawer/ResourcePathAttributeDrawer.cs
+++ b/Editor/Drawers/CustomPicker/ResourcePathDrawer/ResourcePathAttributeDrawer.cs
@@ -49,7 +49,7 @@ namespace SaintsField.Editor.Drawers.CustomPicker.ResourcePathDrawer
                 Object itemObject = itemInfo.Object;
                 Debug.Assert(itemObject, itemObject);
 
-#if UNITY_6000_5_OR_NEWER
+#if UNITY_6000_4_OR_NEWER
                 EntityId targetInstanceId = target.GetEntityId();
 #else
                 int targetInstanceId = target.GetInstanceID();

--- a/Editor/Drawers/CustomPicker/ResourcePathDrawer/ResourcePathAttributeDrawer.cs
+++ b/Editor/Drawers/CustomPicker/ResourcePathDrawer/ResourcePathAttributeDrawer.cs
@@ -49,7 +49,11 @@ namespace SaintsField.Editor.Drawers.CustomPicker.ResourcePathDrawer
                 Object itemObject = itemInfo.Object;
                 Debug.Assert(itemObject, itemObject);
 
+#if UNITY_6000_5_OR_NEWER
+                EntityId targetInstanceId = target.GetEntityId();
+#else
                 int targetInstanceId = target.GetInstanceID();
+#endif
                 if (itemInfo.InstanceID == targetInstanceId)
                 {
                     return true;

--- a/Editor/Drawers/DropdownDrawer/DropdownAttributeDrawerIMGUI.cs
+++ b/Editor/Drawers/DropdownDrawer/DropdownAttributeDrawerIMGUI.cs
@@ -10,7 +10,7 @@ namespace SaintsField.Editor.Drawers.DropdownDrawer
 {
     public partial class DropdownAttributeDrawer
     {
-        private static string GetKey(SerializedProperty property) => $"{property.serializedObject.targetObject.GetInstanceID()}_{property.propertyPath}";
+        private static string GetKey(SerializedProperty property) => SerializedUtils.GetUniqueId(property);
 
         private static readonly Dictionary<string, object> AsyncChangedCache = new Dictionary<string, object>();
 

--- a/Editor/Drawers/ExpandableDrawer/ExpandableAttributeDrawer.cs
+++ b/Editor/Drawers/ExpandableDrawer/ExpandableAttributeDrawer.cs
@@ -123,22 +123,38 @@ namespace SaintsField.Editor.Drawers.ExpandableDrawer
                 return false;
             }
 
+#if UNITY_6000_5_OR_NEWER
+            HashSet<EntityId> instanceIds = new HashSet<EntityId>();
+#else
             HashSet<int> instanceIds = new HashSet<int>();
+#endif
             foreach (Object target in serObj1.targetObjects)
             {
                 if(target)
                 {
+#if UNITY_6000_5_OR_NEWER
+                    instanceIds.Add(target.GetEntityId());
+#else
                     instanceIds.Add(target.GetInstanceID());
+#endif
                 }
             }
 
+#if UNITY_6000_5_OR_NEWER
+            HashSet<EntityId> instanceIds2 = new HashSet<EntityId>();
+#else
             HashSet<int> instanceIds2 = new HashSet<int>();
+#endif
             foreach (Object target in serObj2.targetObjects)
             {
                 // ReSharper disable once InvertIf
                 if(target)
                 {
+#if UNITY_6000_5_OR_NEWER
+                    EntityId id = target.GetEntityId();
+#else
                     int id = target.GetInstanceID();
+#endif
                     if (!instanceIds.Contains(id))
                     {
                         return false;

--- a/Editor/Drawers/ExpandableDrawer/ExpandableAttributeDrawer.cs
+++ b/Editor/Drawers/ExpandableDrawer/ExpandableAttributeDrawer.cs
@@ -123,7 +123,7 @@ namespace SaintsField.Editor.Drawers.ExpandableDrawer
                 return false;
             }
 
-#if UNITY_6000_5_OR_NEWER
+#if UNITY_6000_4_OR_NEWER
             HashSet<EntityId> instanceIds = new HashSet<EntityId>();
 #else
             HashSet<int> instanceIds = new HashSet<int>();
@@ -132,7 +132,7 @@ namespace SaintsField.Editor.Drawers.ExpandableDrawer
             {
                 if(target)
                 {
-#if UNITY_6000_5_OR_NEWER
+#if UNITY_6000_4_OR_NEWER
                     instanceIds.Add(target.GetEntityId());
 #else
                     instanceIds.Add(target.GetInstanceID());
@@ -140,7 +140,7 @@ namespace SaintsField.Editor.Drawers.ExpandableDrawer
                 }
             }
 
-#if UNITY_6000_5_OR_NEWER
+#if UNITY_6000_4_OR_NEWER
             HashSet<EntityId> instanceIds2 = new HashSet<EntityId>();
 #else
             HashSet<int> instanceIds2 = new HashSet<int>();
@@ -150,7 +150,7 @@ namespace SaintsField.Editor.Drawers.ExpandableDrawer
                 // ReSharper disable once InvertIf
                 if(target)
                 {
-#if UNITY_6000_5_OR_NEWER
+#if UNITY_6000_4_OR_NEWER
                     EntityId id = target.GetEntityId();
 #else
                     int id = target.GetInstanceID();

--- a/Editor/Drawers/FolderDrawers/ResourcesFolderDrawer/ResourceFolderAttributeDrawerIMGUI.cs
+++ b/Editor/Drawers/FolderDrawers/ResourcesFolderDrawer/ResourceFolderAttributeDrawerIMGUI.cs
@@ -14,7 +14,7 @@ namespace SaintsField.Editor.Drawers.FolderDrawers.ResourcesFolderDrawer
     {
         private static Texture2D _folderIcon;
 
-        private static string GetKey(SerializedProperty property) => $"{property.serializedObject.targetObject.GetInstanceID()}_{property.propertyPath}";
+        private static string GetKey(SerializedProperty property) => SerializedUtils.GetUniqueId(property);
 
         private class CacheInfo
         {

--- a/Editor/Drawers/GUIColor/GUIColorAttributeDrawerIMGUI.cs
+++ b/Editor/Drawers/GUIColor/GUIColorAttributeDrawerIMGUI.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Reflection;
 using SaintsField.Interfaces;
+using SaintsField.Editor.Utils;
 using UnityEditor;
 using UnityEngine;
 
@@ -10,7 +11,7 @@ namespace SaintsField.Editor.Drawers.GUIColor
     {
         private static readonly Dictionary<string, Color> _idToOriginalColor = new Dictionary<string, Color>();
 
-        private static string GetKey(SerializedProperty property) => $"{property.serializedObject.targetObject.GetInstanceID()}_{property.propertyPath}";
+        private static string GetKey(SerializedProperty property) => SerializedUtils.GetUniqueId(property);
 
         protected override bool WillDrawAbove(SerializedProperty property, ISaintsAttribute saintsAttribute, FieldInfo info, object parent)
         {

--- a/Editor/Drawers/GUIColor/GUIColorAttributeDrawerIMGUI.cs
+++ b/Editor/Drawers/GUIColor/GUIColorAttributeDrawerIMGUI.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using System.Reflection;
-using SaintsField.Interfaces;
 using SaintsField.Editor.Utils;
+using SaintsField.Interfaces;
 using UnityEditor;
 using UnityEngine;
 

--- a/Editor/Drawers/MinMaxSliderDrawer/MinMaxSliderAttributeDrawerIMGUI.cs
+++ b/Editor/Drawers/MinMaxSliderDrawer/MinMaxSliderAttributeDrawerIMGUI.cs
@@ -12,8 +12,7 @@ namespace SaintsField.Editor.Drawers.MinMaxSliderDrawer
 
         private static readonly Dictionary<string, Vector2> IdToMinMaxRange = new Dictionary<string, Vector2>();
 
-        private static string GetKey(SerializedProperty property) =>
-            $"{property.serializedObject.targetObject.GetInstanceID()}_{property.propertyPath}";
+        private static string GetKey(SerializedProperty property) => SerializedUtils.GetUniqueId(property);
 
         private string _error = "";
         private string _cacheKey = "";

--- a/Editor/Drawers/ProgressBarDrawer/ProgressBarAttributeDrawerIMGUI.cs
+++ b/Editor/Drawers/ProgressBarDrawer/ProgressBarAttributeDrawerIMGUI.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Reflection;
 using SaintsField.Editor.Drawers.ExpandableDrawer;
+using SaintsField.Editor.Utils;
 using SaintsField.Interfaces;
 using UnityEditor;
 using UnityEngine;
@@ -29,7 +30,7 @@ namespace SaintsField.Editor.Drawers.ProgressBarDrawer
             FieldInfo info,
             object parent)
         {
-            string arrayKey = $"{property.serializedObject.targetObject.GetInstanceID()}_{property.propertyPath}";
+            string arrayKey = SerializedUtils.GetUniqueIdArray(property);
             // ReSharper disable once CanSimplifyDictionaryLookupWithTryAdd
             if (!_inArrayMousePressed.ContainsKey(arrayKey))
             {

--- a/Editor/Drawers/SaintsInterfacePropertyDrawer/SaintsInterfaceDrawer.cs
+++ b/Editor/Drawers/SaintsInterfacePropertyDrawer/SaintsInterfaceDrawer.cs
@@ -110,7 +110,7 @@ namespace SaintsField.Editor.Drawers.SaintsInterfacePropertyDrawer
                                     failedCount = itemInfo.failedCount,
                                     GuiLabel = itemInfo.GuiLabel,
                                     Icon = itemInfo.Icon,
-#if UNITY_6000_5_OR_NEWER
+#if UNITY_6000_4_OR_NEWER
                                     InstanceID = component.GetEntityId(),
 #else
                                     InstanceID = component.GetInstanceID(),

--- a/Editor/Drawers/SaintsInterfacePropertyDrawer/SaintsInterfaceDrawer.cs
+++ b/Editor/Drawers/SaintsInterfacePropertyDrawer/SaintsInterfaceDrawer.cs
@@ -110,7 +110,11 @@ namespace SaintsField.Editor.Drawers.SaintsInterfacePropertyDrawer
                                     failedCount = itemInfo.failedCount,
                                     GuiLabel = itemInfo.GuiLabel,
                                     Icon = itemInfo.Icon,
+#if UNITY_6000_5_OR_NEWER
+                                    InstanceID = component.GetEntityId(),
+#else
                                     InstanceID = component.GetInstanceID(),
+#endif
                                     Label = components.Count == 1 ? component.name : $"{component.name} [{index}]",
                                     Object = component,
                                     preview = itemInfo.preview,

--- a/Editor/Drawers/XPathDrawers/GetByXPathDrawer/GetByXPathAttributeDrawerPickerWindowIMGUI.cs
+++ b/Editor/Drawers/XPathDrawers/GetByXPathDrawer/GetByXPathAttributeDrawerPickerWindowIMGUI.cs
@@ -51,7 +51,11 @@ namespace SaintsField.Editor.Drawers.XPathDrawers.GetByXPathDrawer
                     Object = each,
                     Label = each.name,
                     // Icon = property.icon,
+#if UNITY_6000_5_OR_NEWER
+                    InstanceID = each.GetEntityId(),
+#else
                     InstanceID = each.GetInstanceID(),
+#endif
                     GuiLabel = new GUIContent(each.name),
                 });
             }
@@ -64,7 +68,11 @@ namespace SaintsField.Editor.Drawers.XPathDrawers.GetByXPathDrawer
                     Object = each,
                     Label = each.name,
                     // Icon = property.icon,
+#if UNITY_6000_5_OR_NEWER
+                    InstanceID = each.GetEntityId(),
+#else
                     InstanceID = each.GetInstanceID(),
+#endif
                     GuiLabel = new GUIContent(each.name),
                 });
             }

--- a/Editor/Drawers/XPathDrawers/GetByXPathDrawer/GetByXPathAttributeDrawerPickerWindowIMGUI.cs
+++ b/Editor/Drawers/XPathDrawers/GetByXPathDrawer/GetByXPathAttributeDrawerPickerWindowIMGUI.cs
@@ -51,7 +51,7 @@ namespace SaintsField.Editor.Drawers.XPathDrawers.GetByXPathDrawer
                     Object = each,
                     Label = each.name,
                     // Icon = property.icon,
-#if UNITY_6000_5_OR_NEWER
+#if UNITY_6000_4_OR_NEWER
                     InstanceID = each.GetEntityId(),
 #else
                     InstanceID = each.GetInstanceID(),
@@ -68,7 +68,7 @@ namespace SaintsField.Editor.Drawers.XPathDrawers.GetByXPathDrawer
                     Object = each,
                     Label = each.name,
                     // Icon = property.icon,
-#if UNITY_6000_5_OR_NEWER
+#if UNITY_6000_4_OR_NEWER
                     InstanceID = each.GetEntityId(),
 #else
                     InstanceID = each.GetInstanceID(),

--- a/Editor/Utils/SaintsObjectPickerWindow/SaintsObjectPickerWindowIMGUI.cs
+++ b/Editor/Utils/SaintsObjectPickerWindow/SaintsObjectPickerWindowIMGUI.cs
@@ -55,7 +55,7 @@ namespace SaintsField.Editor.Utils.SaintsObjectPickerWindow
             public Object Object;
             public Texture2D Icon;
             // public bool HasInstanceId;
-#if UNITY_6000_5_OR_NEWER
+#if UNITY_6000_4_OR_NEWER
             public EntityId InstanceID;
 #else
             public int InstanceID;
@@ -71,7 +71,7 @@ namespace SaintsField.Editor.Utils.SaintsObjectPickerWindow
         private static readonly ItemInfo NullItemInfo = new ItemInfo
         {
             Icon = null,
-#if UNITY_6000_5_OR_NEWER
+#if UNITY_6000_4_OR_NEWER
             InstanceID = EntityId.None,
 #else
             InstanceID = int.MinValue,

--- a/Editor/Utils/SaintsObjectPickerWindow/SaintsObjectPickerWindowIMGUI.cs
+++ b/Editor/Utils/SaintsObjectPickerWindow/SaintsObjectPickerWindowIMGUI.cs
@@ -55,7 +55,11 @@ namespace SaintsField.Editor.Utils.SaintsObjectPickerWindow
             public Object Object;
             public Texture2D Icon;
             // public bool HasInstanceId;
+#if UNITY_6000_5_OR_NEWER
+            public EntityId InstanceID;
+#else
             public int InstanceID;
+#endif
             public string Label;
             public GUIContent GuiLabel;
             // ReSharper enable InconsistentNaming
@@ -67,7 +71,11 @@ namespace SaintsField.Editor.Utils.SaintsObjectPickerWindow
         private static readonly ItemInfo NullItemInfo = new ItemInfo
         {
             Icon = null,
+#if UNITY_6000_5_OR_NEWER
+            InstanceID = EntityId.None,
+#else
             InstanceID = int.MinValue,
+#endif
             Label = "None",
             Object = null,
             preview = null,

--- a/Editor/Utils/SerializedUtils.cs
+++ b/Editor/Utils/SerializedUtils.cs
@@ -243,7 +243,11 @@ namespace SaintsField.Editor.Utils
             string[] paths = property.propertyPath.Split(DotSplitSeparator);
 
             (bool _, string[] propPathSegments) = TrimEndArray(paths);
+#if UNITY_6000_5_OR_NEWER
+            return $"{EntityId.ToULong(property.serializedObject.targetObject.GetEntityId())}_{string.Join(".", propPathSegments)}";
+#else
             return $"{property.serializedObject.targetObject.GetInstanceID()}_{string.Join(".", propPathSegments)}";
+#endif
         }
 
         public static (string error, SerializedProperty property) GetArrayProperty(SerializedProperty property)
@@ -384,14 +388,22 @@ namespace SaintsField.Editor.Utils
 
         public static string GetUniqueId(SerializedProperty property)
         {
+#if UNITY_6000_5_OR_NEWER
+            return $"{EntityId.ToULong(property.serializedObject.targetObject.GetEntityId())}_{property.propertyPath}";
+#else
             return $"{property.serializedObject.targetObject.GetInstanceID()}_{property.propertyPath}";
+#endif
         }
 
         public static bool IsOk(SerializedProperty property)
         {
             try
             {
+#if UNITY_6000_5_OR_NEWER
+                EntityId _ = property.serializedObject.targetObject.GetEntityId();
+#else
                 int _ = property.serializedObject.targetObject.GetInstanceID();
+#endif
                 string __ = property.propertyPath;
                 string ___ = property.displayName;
             }

--- a/Editor/Utils/SerializedUtils.cs
+++ b/Editor/Utils/SerializedUtils.cs
@@ -243,7 +243,7 @@ namespace SaintsField.Editor.Utils
             string[] paths = property.propertyPath.Split(DotSplitSeparator);
 
             (bool _, string[] propPathSegments) = TrimEndArray(paths);
-#if UNITY_6000_5_OR_NEWER
+#if UNITY_6000_4_OR_NEWER
             return $"{EntityId.ToULong(property.serializedObject.targetObject.GetEntityId())}_{string.Join(".", propPathSegments)}";
 #else
             return $"{property.serializedObject.targetObject.GetInstanceID()}_{string.Join(".", propPathSegments)}";
@@ -388,7 +388,7 @@ namespace SaintsField.Editor.Utils
 
         public static string GetUniqueId(SerializedProperty property)
         {
-#if UNITY_6000_5_OR_NEWER
+#if UNITY_6000_4_OR_NEWER
             return $"{EntityId.ToULong(property.serializedObject.targetObject.GetEntityId())}_{property.propertyPath}";
 #else
             return $"{property.serializedObject.targetObject.GetInstanceID()}_{property.propertyPath}";
@@ -399,7 +399,7 @@ namespace SaintsField.Editor.Utils
         {
             try
             {
-#if UNITY_6000_5_OR_NEWER
+#if UNITY_6000_4_OR_NEWER
                 EntityId _ = property.serializedObject.targetObject.GetEntityId();
 #else
                 int _ = property.serializedObject.targetObject.GetInstanceID();


### PR DESCRIPTION
This PR makes all the changes needed for Unity 6.5 whilst keeping full backwards compatibility.
I tried to keep the code as similar to before as possible, whilst making some tiny improvements, such as removing duplicated code from classes:
```cs
private static string GetKey(SerializedProperty property) => $"{property.serializedObject.targetObject.GetInstanceID()}_{property.propertyPath}";
```
And replacing it with the existing util:
```cs
private static string GetKey(SerializedProperty property) => SerializedUtils.GetUniqueId(property);
```
This should simplify updating the asset in the future, as well as reduce the room for errors.