### PR TITLE
Add a util for safely getting types from an Assembly

### DIFF
--- a/Editor/Core/SaintsPropertyDrawer.cs
+++ b/Editor/Core/SaintsPropertyDrawer.cs
@@ -188,7 +188,7 @@ namespace SaintsField.Editor.Core
                 }
 #endif
 
-                Type[] allTypes = asb.GetTypes();
+                Type[] allTypes = Util.GetAssemblyTypesSafe(asb);
 
                 // foreach (Type editorType in allTypes.Where(type => type.IsSubclassOf(typeof(UnityEditor.Editor))))
                 // {

--- a/Editor/Drawers/SaintsInterfacePropertyDrawer/SaintsInterfaceDrawer.cs
+++ b/Editor/Drawers/SaintsInterfacePropertyDrawer/SaintsInterfaceDrawer.cs
@@ -190,15 +190,7 @@ namespace SaintsField.Editor.Drawers.SaintsInterfacePropertyDrawer
             List<Type> results = new List<Type>();
             foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies())
             {
-                IEnumerable<Type> assemblyTypes;
-                try
-                {
-                    assemblyTypes = assembly.GetTypes();
-                }
-                catch (ReflectionTypeLoadException e)
-                {
-                    assemblyTypes = e.Types.Where(each => each != null);
-                }
+                IEnumerable<Type> assemblyTypes = Util.GetAssemblyTypesSafe(assembly);
 
                 results.AddRange(assemblyTypes.Where(type =>
                     type != null

--- a/Editor/Drawers/SaintsWrapTypeDrawer/SaintsWrapElement.cs
+++ b/Editor/Drawers/SaintsWrapTypeDrawer/SaintsWrapElement.cs
@@ -222,7 +222,7 @@ namespace SaintsField.Editor.Drawers.SaintsWrapTypeDrawer
         private IReadOnlyList<Type> GetTypesImplementingInterface(Type interfaceType)
         {
             return _cachedTypesImplementingInterface ??= AppDomain.CurrentDomain.GetAssemblies()
-                .SelectMany(assembly => assembly.GetTypes())
+                .SelectMany(Util.GetAssemblyTypesSafe)
                 .Where(type => !type.IsAbstract
                                &&!typeof(Object).IsAssignableFrom(type)
                                && interfaceType.IsAssignableFrom(type))

--- a/Editor/Drawers/TypeReferenceTypeDrawer/TypeReferenceDrawer.cs
+++ b/Editor/Drawers/TypeReferenceTypeDrawer/TypeReferenceDrawer.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Reflection;
 using SaintsField.Editor.Core;
 using SaintsField.Editor.Drawers.AdvancedDropdownDrawer;
+using SaintsField.Editor.Utils;
 using UnityEditor;
 using UnityEngine;
 
@@ -168,7 +169,7 @@ namespace SaintsField.Editor.Drawers.TypeReferenceTypeDrawer
             {
                 if (!toFill.ContainsKey(assembly))
                 {
-                    toFill[assembly] = assembly.GetTypes();
+                    toFill[assembly] = Util.GetAssemblyTypesSafe(assembly);
                 }
             }
         }

--- a/Editor/Drawers/XPathDrawers/GetByXPathDrawer/GetByXPathAttributeDrawerTargetGetter.cs
+++ b/Editor/Drawers/XPathDrawers/GetByXPathDrawer/GetByXPathAttributeDrawerTargetGetter.cs
@@ -1348,17 +1348,7 @@ namespace SaintsField.Editor.Drawers.XPathDrawers.GetByXPathDrawer
                 : shortOrQualifiedName;
 
             _cachedAssemblyTypes ??= AppDomain.CurrentDomain.GetAssemblies()
-                .ToDictionary(assembly => assembly, assembly =>
-                {
-                    try
-                    {
-                        return assembly.GetTypes();
-                    }
-                    catch
-                    {
-                        return Array.Empty<Type>();
-                    }
-                });
+                .ToDictionary(assembly => assembly, Util.GetAssemblyTypesSafe);
 
             List<Type> exactlyFullMatchedTypes = new List<Type>();
             List<Type> unityEngineTypes = new List<Type>();

--- a/Editor/TroubleshootEditor/TroubleshootEditorWindow.cs
+++ b/Editor/TroubleshootEditor/TroubleshootEditorWindow.cs
@@ -73,7 +73,7 @@ namespace SaintsField.Editor.TroubleshootEditor
 
             foreach (Assembly asb in AppDomain.CurrentDomain.GetAssemblies())
             {
-                Type[] allTypes = asb.GetTypes();
+                Type[] allTypes = Util.GetAssemblyTypesSafe(asb);
                 List<Type> allEditors = allTypes
                     .Where(type => type.IsSubclassOf(typeof(UnityEditor.Editor)))
                     .ToList();

--- a/Editor/Utils/Util.cs
+++ b/Editor/Utils/Util.cs
@@ -1240,11 +1240,20 @@ namespace SaintsField.Editor.Utils
             }
         }
 
+        public static Type[] GetAssemblyTypesSafe(Assembly assembly)
+        {
+            try {
+                return assembly.GetTypes();
+            } catch (ReflectionTypeLoadException e) {
+                return e.Types.Where(each => each != null).ToArray();
+            }
+        }
+
         private static Type FindTypeInAssembly(Assembly assembly, IReadOnlyList<string> split)
         {
             return split.Count > 1
                 ? assembly.GetType(string.Join(".", split), false)
-                : assembly.GetTypes().FirstOrDefault(t => t.Name == split[0]);
+                : GetAssemblyTypesSafe(assembly).FirstOrDefault(t => t.Name == split[0]);
         }
 
         private static (string error, MemberInfo memberInfo, T result) GetOfStatic<T>(string nameSpaceAndName, T defaultValue, SerializedProperty property, MemberInfo memberInfo, object target, IReadOnlyList<object> overrideParams)


### PR DESCRIPTION
Calling GetTypes on an Assembly can sometimes throw an exception. Depending on where it happens, this can result in all inspector windows being rendered nonfunctional.

This adds a util method which will catch any exception when getting types, and return the types that were able to be loaded, if any.

For context, after upgrading our project to Unity 6.5, we started getting exceptions from a dynamic assembly named `AsmDefToCSProjLib` when attempting to get types from it. This has been quite hard to debug since the assembly doesn't always exist and doesn't always throw. SaintsField is the biggest thing it affects, completely breaking the inspector, so I figured I'd upstream this patch to prevent any similar issues from happening in the future, along with immediately fixing the worst symptom of our issue.