### PR TITLE
Use CurrentAssemblies for getting assemblies in Unity 6000.4+

### DIFF
--- a/Editor/Core/SaintsPropertyDrawer.cs
+++ b/Editor/Core/SaintsPropertyDrawer.cs
@@ -179,7 +179,7 @@ namespace SaintsField.Editor.Core
             Dictionary<Type, HashSet<Type>> attrToDecoratorDrawers =
                 new Dictionary<Type, HashSet<Type>>();
 
-            foreach (Assembly asb in AppDomain.CurrentDomain.GetAssemblies())
+            foreach (Assembly asb in Util.GetAssemblies())
             {
 #if UNITY_2022_1_OR_NEWER
                 if (asb.GetName().Name == "UnityEditor")

--- a/Editor/Drawers/SaintsInterfacePropertyDrawer/SaintsInterfaceDrawer.cs
+++ b/Editor/Drawers/SaintsInterfacePropertyDrawer/SaintsInterfaceDrawer.cs
@@ -188,7 +188,7 @@ namespace SaintsField.Editor.Drawers.SaintsInterfacePropertyDrawer
             }
 
             List<Type> results = new List<Type>();
-            foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies())
+            foreach (Assembly assembly in Util.GetAssemblies())
             {
                 IEnumerable<Type> assemblyTypes;
                 try

--- a/Editor/Drawers/SaintsWrapTypeDrawer/SaintsWrapElement.cs
+++ b/Editor/Drawers/SaintsWrapTypeDrawer/SaintsWrapElement.cs
@@ -221,7 +221,7 @@ namespace SaintsField.Editor.Drawers.SaintsWrapTypeDrawer
 
         private IReadOnlyList<Type> GetTypesImplementingInterface(Type interfaceType)
         {
-            return _cachedTypesImplementingInterface ??= AppDomain.CurrentDomain.GetAssemblies()
+            return _cachedTypesImplementingInterface ??= Util.GetAssemblies()
                 .SelectMany(assembly => assembly.GetTypes())
                 .Where(type => !type.IsAbstract
                                &&!typeof(Object).IsAssignableFrom(type)

--- a/Editor/Drawers/TypeReferenceTypeDrawer/TypeReferenceDrawer.cs
+++ b/Editor/Drawers/TypeReferenceTypeDrawer/TypeReferenceDrawer.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Reflection;
 using SaintsField.Editor.Core;
 using SaintsField.Editor.Drawers.AdvancedDropdownDrawer;
+using SaintsField.Editor.Utils;
 using UnityEditor;
 using UnityEngine;
 
@@ -62,7 +63,7 @@ namespace SaintsField.Editor.Drawers.TypeReferenceTypeDrawer
             // ReSharper disable once ConvertIfStatementToNullCoalescingAssignment
             if (_allAssemblies == null)
             {
-                _allAssemblies = AppDomain.CurrentDomain.GetAssemblies();
+                _allAssemblies = Util.GetAssemblies();
             }
 
             foreach (Assembly assembly in _allAssemblies)
@@ -129,7 +130,7 @@ namespace SaintsField.Editor.Drawers.TypeReferenceTypeDrawer
                 // ReSharper disable once ConvertIfStatementToNullCoalescingAssignment
                 if (_allAssemblies == null)
                 {
-                    _allAssemblies = AppDomain.CurrentDomain.GetAssemblies();
+                    _allAssemblies = Util.GetAssemblies();
                 }
 
                 foreach (Assembly assembly in _allAssemblies)

--- a/Editor/Drawers/XPathDrawers/GetByXPathDrawer/GetByXPathAttributeDrawerTargetGetter.cs
+++ b/Editor/Drawers/XPathDrawers/GetByXPathDrawer/GetByXPathAttributeDrawerTargetGetter.cs
@@ -1347,7 +1347,7 @@ namespace SaintsField.Editor.Drawers.XPathDrawers.GetByXPathDrawer
                 ? shortOrQualifiedName.Split('.').Last()
                 : shortOrQualifiedName;
 
-            _cachedAssemblyTypes ??= AppDomain.CurrentDomain.GetAssemblies()
+            _cachedAssemblyTypes ??= Util.GetAssemblies()
                 .ToDictionary(assembly => assembly, assembly =>
                 {
                     try

--- a/Editor/TroubleshootEditor/TroubleshootEditorWindow.cs
+++ b/Editor/TroubleshootEditor/TroubleshootEditorWindow.cs
@@ -71,7 +71,7 @@ namespace SaintsField.Editor.TroubleshootEditor
 
             _propertyTypeToDrawers.Clear();
 
-            foreach (Assembly asb in AppDomain.CurrentDomain.GetAssemblies())
+            foreach (Assembly asb in Util.GetAssemblies())
             {
                 Type[] allTypes = asb.GetTypes();
                 List<Type> allEditors = allTypes

--- a/Editor/Utils/Util.cs
+++ b/Editor/Utils/Util.cs
@@ -1240,6 +1240,16 @@ namespace SaintsField.Editor.Utils
             }
         }
 
+        public static IReadOnlyList<Assembly> GetAssemblies() 
+        {
+#if UNITY_6000_4_OR_NEWER
+            // https://docs.unity3d.com/6000.4/Documentation/ScriptReference/Assemblies.CurrentAssemblies.GetLoadedAssemblies
+            return UnityEngine.Assemblies.CurrentAssemblies.GetLoadedAssemblies();
+#else
+            return AppDomain.CurrentDomain.GetAssemblies();
+#endif
+        }
+
         private static Type FindTypeInAssembly(Assembly assembly, IReadOnlyList<string> split)
         {
             return split.Count > 1
@@ -1274,7 +1284,7 @@ namespace SaintsField.Editor.Utils
             }
             if (type == null && fullSearch)
             {
-                foreach (Assembly searchAssembly in AppDomain.CurrentDomain.GetAssemblies())
+                foreach (Assembly searchAssembly in GetAssemblies())
                 {
                     type = FindTypeInAssembly(searchAssembly, split);
                     if (type != null)


### PR DESCRIPTION
This is now the "proper" way to get assemblies in 6.4+

See #424 for more context.