### PR TITLE
Safely enumerate assembly types everywhere

### DIFF
--- a/Editor/Core/SaintsPropertyDrawer.cs
+++ b/Editor/Core/SaintsPropertyDrawer.cs
@@ -188,7 +188,7 @@ namespace SaintsField.Editor.Core
                 }
 #endif
 
-                Type[] allTypes = asb.GetTypes();
+                Type[] allTypes = Util.GetAssemblyTypesSafe(asb);
 
                 // foreach (Type editorType in allTypes.Where(type => type.IsSubclassOf(typeof(UnityEditor.Editor))))
                 // {

--- a/Editor/Drawers/SaintsInterfacePropertyDrawer/SaintsInterfaceDrawer.cs
+++ b/Editor/Drawers/SaintsInterfacePropertyDrawer/SaintsInterfaceDrawer.cs
@@ -190,15 +190,7 @@ namespace SaintsField.Editor.Drawers.SaintsInterfacePropertyDrawer
             List<Type> results = new List<Type>();
             foreach (Assembly assembly in Util.GetAssemblies())
             {
-                IEnumerable<Type> assemblyTypes;
-                try
-                {
-                    assemblyTypes = assembly.GetTypes();
-                }
-                catch (ReflectionTypeLoadException e)
-                {
-                    assemblyTypes = e.Types.Where(each => each != null);
-                }
+                IEnumerable<Type> assemblyTypes = Util.GetAssemblyTypesSafe(assembly);
 
                 results.AddRange(assemblyTypes.Where(type =>
                     type != null

--- a/Editor/Drawers/SaintsWrapTypeDrawer/SaintsWrapElement.cs
+++ b/Editor/Drawers/SaintsWrapTypeDrawer/SaintsWrapElement.cs
@@ -222,7 +222,7 @@ namespace SaintsField.Editor.Drawers.SaintsWrapTypeDrawer
         private IReadOnlyList<Type> GetTypesImplementingInterface(Type interfaceType)
         {
             return _cachedTypesImplementingInterface ??= Util.GetAssemblies()
-                .SelectMany(assembly => assembly.GetTypes())
+                .SelectMany(Util.GetAssemblyTypesSafe)
                 .Where(type => !type.IsAbstract
                                &&!typeof(Object).IsAssignableFrom(type)
                                && interfaceType.IsAssignableFrom(type))

--- a/Editor/Drawers/XPathDrawers/GetByXPathDrawer/GetByXPathAttributeDrawerTargetGetter.cs
+++ b/Editor/Drawers/XPathDrawers/GetByXPathDrawer/GetByXPathAttributeDrawerTargetGetter.cs
@@ -1348,17 +1348,7 @@ namespace SaintsField.Editor.Drawers.XPathDrawers.GetByXPathDrawer
                 : shortOrQualifiedName;
 
             _cachedAssemblyTypes ??= Util.GetAssemblies()
-                .ToDictionary(assembly => assembly, assembly =>
-                {
-                    try
-                    {
-                        return assembly.GetTypes();
-                    }
-                    catch
-                    {
-                        return Array.Empty<Type>();
-                    }
-                });
+                .ToDictionary(assembly => assembly, Util.GetAssemblyTypesSafe);
 
             List<Type> exactlyFullMatchedTypes = new List<Type>();
             List<Type> unityEngineTypes = new List<Type>();

--- a/Editor/TroubleshootEditor/TroubleshootEditorWindow.cs
+++ b/Editor/TroubleshootEditor/TroubleshootEditorWindow.cs
@@ -73,7 +73,7 @@ namespace SaintsField.Editor.TroubleshootEditor
 
             foreach (Assembly asb in Util.GetAssemblies())
             {
-                Type[] allTypes = asb.GetTypes();
+                Type[] allTypes = Util.GetAssemblyTypesSafe(asb);
                 List<Type> allEditors = allTypes
                     .Where(type => type.IsSubclassOf(typeof(UnityEditor.Editor)))
                     .ToList();

--- a/Editor/Utils/Util.cs
+++ b/Editor/Utils/Util.cs
@@ -1281,7 +1281,7 @@ namespace SaintsField.Editor.Utils
             }
             else
             {
-                foreach (Type t in assembly.GetTypes())
+                foreach (Type t in GetAssemblyTypesSafe(assembly))
                 {
                     if (t.Name == split[0])
                     {
@@ -1289,7 +1289,7 @@ namespace SaintsField.Editor.Utils
                     }
                 }
             }
-                // return assembly.GetTypes().FirstOrDefault(t => t.Name == split[0]);
+                // return GetAssemblyTypesSafe(assembly).FirstOrDefault(t => t.Name == split[0]);
         }
 
         private static (string error, MemberInfo memberInfo, T result) GetOfStatic<T>(string nameSpaceAndName, T defaultValue, SerializedProperty property, MemberInfo memberInfo, object target, IReadOnlyList<object> overrideParams)


### PR DESCRIPTION
This is a semi-continuation of #424. fc8c0a528f14b2a3da86cc6eb6e97f3662453ca7 implemented what that PR was doing, but didn't use that util everywhere, which needs to be done, otherwise it's essentially useless. This fixes up all remaining Assembly.GetTypes calls to use the safer util method.